### PR TITLE
Identify glyphs by glyph id instead of codepoint

### DIFF
--- a/docs/en/guide/advanced/font-collections.md
+++ b/docs/en/guide/advanced/font-collections.md
@@ -32,7 +32,7 @@ from torchfont.transforms import LoadGlyph
 
 ref = GlyphRef(
     font=FontRef("data/fonts/example.ttc", ttc_index=2),
-    codepoint=ord("A"),
+    glyph_id=36,
 )
 outline = LoadGlyph()(ref)
 ```

--- a/docs/en/guide/advanced/torch-compile.md
+++ b/docs/en/guide/advanced/torch-compile.md
@@ -7,14 +7,12 @@ Load the glyph first, then compile the tensor-only part of the pipeline:
 ```python
 import torch
 
-from torchfont import FontRef, GlyphRef, Outline
+from torchfont import Outline
+from torchfont.datasets import GlyphDataset
 from torchfont.transforms import functional as F
 
-ref = GlyphRef(
-    font=FontRef("path/to/font.ttf", ttc_index=0),
-    codepoint=ord("A"),
-)
-outline = F.load_glyph(ref)
+dataset = GlyphDataset("data/fonts", codepoints=[ord("A")])
+outline = F.load_glyph(dataset[0].ref)
 
 
 def pipeline(types: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:

--- a/docs/en/guide/basic/glyph-data-format.md
+++ b/docs/en/guide/basic/glyph-data-format.md
@@ -27,6 +27,7 @@ types, coords = outline.types, outline.coords
 print(data.ref)  # glyph reference
 print(types)  # element type sequence
 print(coords)  # coordinates sequence
+print(data.codepoint)  # Unicode codepoint
 print(data.font_idx)  # font face class ID
 print(data.character_idx)  # character class ID
 print(data.weight)  # OpenType weight

--- a/docs/en/reference/core-types.md
+++ b/docs/en/reference/core-types.md
@@ -81,9 +81,9 @@ Splits an `Outline` with exactly one batch dimension and removes trailing
 ### `GlyphData`
 
 `GlyphData` contains a transformed payload, glyph
-reference, resolved variation location, and the parallel `font_idx`,
-`character_idx`, `weight`, `width`, `italic`, `slant`, and `optical_size`
-targets. Unavailable continuous targets are `None`.
+reference, resolved variation location, and the parallel `codepoint`,
+`font_idx`, `character_idx`, `weight`, `width`, `italic`, `slant`, and
+`optical_size` targets. Unavailable continuous targets are `None`.
 
 `location` is an ordinary `dict[str, float]` mapping OpenType axis tags to the
 values used to load the glyph.

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -19,8 +19,8 @@ Without a transform, `dataset[i]` returns a pickle-friendly `GlyphSample`:
 | Type | Fields |
 |---|---|
 | `FontRef` | `path: str`, `ttc_index: int` |
-| `GlyphRef` | `font: FontRef`, `codepoint: int` |
-| `GlyphSample` | `ref: GlyphRef`, `font_idx: int`, `character_idx: int` |
+| `GlyphRef` | `font: FontRef`, `glyph_id: int` |
+| `GlyphSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
 
 ## `GlyphDataset`
 

--- a/docs/ja/guide/advanced/font-collections.md
+++ b/docs/ja/guide/advanced/font-collections.md
@@ -32,7 +32,7 @@ from torchfont.transforms import LoadGlyph
 
 ref = GlyphRef(
     font=FontRef("data/fonts/example.ttc", ttc_index=2),
-    codepoint=ord("A"),
+    glyph_id=36,
 )
 outline = LoadGlyph()(ref)
 ```

--- a/docs/ja/guide/advanced/torch-compile.md
+++ b/docs/ja/guide/advanced/torch-compile.md
@@ -7,14 +7,12 @@ TorchFont の Functional Transform は、
 ```python
 import torch
 
-from torchfont import FontRef, GlyphRef, Outline
+from torchfont import Outline
+from torchfont.datasets import GlyphDataset
 from torchfont.transforms import functional as F
 
-ref = GlyphRef(
-    font=FontRef("path/to/font.ttf", ttc_index=0),
-    codepoint=ord("A"),
-)
-outline = F.load_glyph(ref)
+dataset = GlyphDataset("data/fonts", codepoints=[ord("A")])
+outline = F.load_glyph(dataset[0].ref)
 
 
 def pipeline(types: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:

--- a/docs/ja/guide/basic/glyph-data-format.md
+++ b/docs/ja/guide/basic/glyph-data-format.md
@@ -29,6 +29,7 @@ types, coords = outline.types, outline.coords
 print(data.ref)  # グリフ参照
 print(types)  # 要素型の系列
 print(coords)  # 座標の系列
+print(data.codepoint)  # Unicode コードポイント
 print(data.font_idx)  # フォントフェイスのクラス ID
 print(data.character_idx)  # 文字のクラス ID
 print(data.weight)  # OpenType のウェイト

--- a/docs/ja/reference/core-types.md
+++ b/docs/ja/reference/core-types.md
@@ -78,8 +78,8 @@ Padding を保持する場合は `Outline.unbind()` を使います。
 ### `GlyphData`
 
 `GlyphData` は変換後の Payload、Glyph 参照、Variation Location、
-並列な `font_idx`、`character_idx`、`weight`、`width`、`italic`、`slant`、
-`optical_size` Target を保持します。取得できない連続 Target は `None` です。
+並列な `codepoint`、`font_idx`、`character_idx`、`weight`、`width`、`italic`、
+`slant`、`optical_size` Target を保持します。取得できない連続 Target は `None` です。
 
 `location` は Glyph の読み込みに使った OpenType Axis Tag と値を保持する通常の
 `dict[str, float]` です。

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -19,8 +19,8 @@ dataset = GlyphDataset(
 | 型 | フィールド |
 |---|---|
 | `FontRef` | `path: str`, `ttc_index: int` |
-| `GlyphRef` | `font: FontRef`, `codepoint: int` |
-| `GlyphSample` | `ref: GlyphRef`, `font_idx: int`, `character_idx: int` |
+| `GlyphRef` | `font: FontRef`, `glyph_id: int` |
+| `GlyphSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
 
 ## `GlyphDataset`
 

--- a/src/dataset/discovered_font.rs
+++ b/src/dataset/discovered_font.rs
@@ -9,6 +9,7 @@ pub(crate) struct DiscoveredFont {
     path: PathBuf,
     ttc_index: u32,
     codepoints: Vec<u32>,
+    glyph_ids: Vec<u32>,
 }
 
 impl DiscoveredFont {
@@ -38,8 +39,8 @@ impl DiscoveredFont {
         Ok(entries)
     }
 
-    pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>) {
-        (self.path, self.ttc_index, self.codepoints)
+    pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>, Vec<u32>) {
+        (self.path, self.ttc_index, self.codepoints, self.glyph_ids)
     }
 
     pub(crate) fn codepoint_count(&self) -> usize {
@@ -62,13 +63,15 @@ impl DiscoveredFont {
             .filter(|(_, glyph_id)| outline_glyphs.get(*glyph_id).is_some())
             .collect();
         mappings.sort_unstable_by_key(|entry| entry.0);
+        let (codepoints, glyph_ids) = mappings
+            .into_iter()
+            .map(|(codepoint, glyph_id)| (codepoint, glyph_id.to_u32()))
+            .unzip();
         Self {
             path: path.to_path_buf(),
             ttc_index,
-            codepoints: mappings
-                .into_iter()
-                .map(|(codepoint, _)| codepoint)
-                .collect(),
+            codepoints,
+            glyph_ids,
         }
     }
 }

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -1,29 +1,38 @@
 use std::path::PathBuf;
 
+/// One discovered face: its file, TTC index, and the codepoint/glyph id pairs
+/// it contributes, sorted by codepoint.
+pub(crate) type IndexedFace = (PathBuf, u32, Vec<u32>, Vec<u32>);
+
 /// Flat sample index over discovered font faces.
 ///
 /// Samples are laid out face by face: face `i` owns the half-open sample range
 /// `offsets[i]..offsets[i + 1]`, so `offsets` has one more element than `fonts`
-/// and its last element is the total sample count. The codepoint of sample `s`
-/// is `character_codepoints[character_index[s]]`.
+/// and its last element is the total sample count. Sample `s` draws glyph
+/// `glyph_ids[s]`, whose codepoint is `character_codepoints[character_index[s]]`.
 pub(crate) struct FontIndex {
     pub(crate) fonts: Vec<(PathBuf, u32)>,
     pub(crate) offsets: Vec<i64>,
     pub(crate) character_codepoints: Vec<u32>,
     pub(crate) character_index: Vec<u32>,
+    pub(crate) glyph_ids: Vec<u32>,
 }
 
 impl FontIndex {
     /// Builds an index from faces whose codepoints are sorted in ascending order.
-    pub(crate) fn build(faces: Vec<(PathBuf, u32, Vec<u32>)>) -> Self {
+    pub(crate) fn build(faces: Vec<IndexedFace>) -> Self {
         let mut fonts = Vec::with_capacity(faces.len());
         let mut offsets = Vec::with_capacity(faces.len() + 1);
-        let mut codepoints = Vec::with_capacity(faces.iter().map(|face| face.2.len()).sum());
+        let sample_count = faces.iter().map(|face| face.2.len()).sum();
+        let mut codepoints = Vec::with_capacity(sample_count);
+        let mut glyph_ids = Vec::with_capacity(sample_count);
         offsets.push(0);
-        for (path, ttc_index, face_codepoints) in faces {
+        for (path, ttc_index, face_codepoints, face_glyph_ids) in faces {
             debug_assert!(face_codepoints.is_sorted());
+            debug_assert_eq!(face_codepoints.len(), face_glyph_ids.len());
             fonts.push((path, ttc_index));
             codepoints.extend(face_codepoints);
+            glyph_ids.extend(face_glyph_ids);
             offsets.push(i64::try_from(codepoints.len()).expect("Vec length fits in i64"));
         }
         let mut character_codepoints = codepoints.clone();
@@ -43,6 +52,7 @@ impl FontIndex {
             offsets,
             character_codepoints,
             character_index,
+            glyph_ids,
         }
     }
 }
@@ -56,8 +66,8 @@ mod tests {
     #[test]
     fn indexes_each_face_codepoint_once() {
         let index = FontIndex::build(vec![
-            (PathBuf::from("a.ttf"), 0, vec![65, 67]),
-            (PathBuf::from("b.ttf"), 1, vec![66]),
+            (PathBuf::from("a.ttf"), 0, vec![65, 67], vec![36, 38]),
+            (PathBuf::from("b.ttf"), 1, vec![66], vec![5]),
         ]);
         assert_eq!(
             index.fonts,
@@ -66,6 +76,7 @@ mod tests {
         assert_eq!(index.offsets, vec![0, 2, 3]);
         assert_eq!(index.character_codepoints, vec![65, 66, 67]);
         assert_eq!(index.character_index, vec![0, 2, 1]);
+        assert_eq!(index.glyph_ids, vec![36, 38, 5]);
     }
 
     #[test]
@@ -75,5 +86,6 @@ mod tests {
         assert_eq!(index.offsets, vec![0]);
         assert!(index.character_codepoints.is_empty());
         assert!(index.character_index.is_empty());
+        assert!(index.glyph_ids.is_empty());
     }
 }

--- a/src/py/dataset/index.rs
+++ b/src/py/dataset/index.rs
@@ -10,6 +10,7 @@ type FontIndexArrays = (
     Vec<i64>,
     Py<PyArray1<u32>>,
     Py<PyArray1<u32>>,
+    Py<PyArray1<u32>>,
 );
 
 #[pyfunction]
@@ -34,6 +35,7 @@ pub(super) fn index_fonts(
             .into_pyarray(py)
             .unbind(),
         index.character_index.into_pyarray(py).unbind(),
+        index.glyph_ids.into_pyarray(py).unbind(),
     ))
 }
 

--- a/src/py/transform/load.rs
+++ b/src/py/transform/load.rs
@@ -52,10 +52,10 @@ pub(crate) fn load_glyph<'py>(
     py: Python<'py>,
     path: PathBuf,
     ttc_index: u32,
-    codepoint: u32,
+    glyph_id: u32,
     location: Option<BTreeMap<String, f32>>,
 ) -> PyResult<super::OutlineArrays<'py>> {
     let outline =
-        py.detach(|| load_glyph_outline(&path, ttc_index, codepoint, location.as_ref()))?;
+        py.detach(|| load_glyph_outline(&path, ttc_index, glyph_id, location.as_ref()))?;
     Ok(super::encode(py, &outline))
 }

--- a/src/transform/load.rs
+++ b/src/transform/load.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, path::Path};
 
 use skrifa::{
-    MetadataProvider,
+    GlyphId, MetadataProvider,
     instance::{LocationRef, Size},
     outline::DrawSettings,
     raw::TableProvider,
@@ -16,7 +16,7 @@ use crate::{
 pub(crate) fn load_glyph_outline(
     path: &Path,
     ttc_index: u32,
-    codepoint: u32,
+    glyph_id: u32,
     location: Option<&BTreeMap<String, f32>>,
 ) -> Result<BezPath, Error> {
     let data = map_font(path)?;
@@ -36,20 +36,16 @@ pub(crate) fn load_glyph_outline(
             path.display()
         )));
     }
-    let glyph_id = font.charmap().map(codepoint).ok_or_else(|| {
-        Error::OutOfRange(format!(
-            "codepoint U+{codepoint:04X} missing from '{}'",
-            path.display()
-        ))
-    })?;
     let user_location = canonicalize_location(&font, path, ttc_index, location)?;
-    let glyph = font.outline_glyphs().get(glyph_id).ok_or_else(|| {
-        Error::Parse(format!(
-            "glyph id {} missing from '{}'",
-            glyph_id.to_u32(),
-            path.display()
-        ))
-    })?;
+    let glyph = font
+        .outline_glyphs()
+        .get(GlyphId::new(glyph_id))
+        .ok_or_else(|| {
+            Error::OutOfRange(format!(
+                "glyph id {glyph_id} missing from '{}' (ttc_index {ttc_index})",
+                path.display()
+            ))
+        })?;
     let location = font.axes().location(
         user_location
             .iter()
@@ -65,9 +61,14 @@ pub(crate) fn load_glyph_outline(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    use crate::error::Error;
+    use skrifa::MetadataProvider as _;
+
+    use crate::{
+        error::Error,
+        font::{map_font, parse_font_ref},
+    };
 
     use super::load_glyph_outline;
 
@@ -76,15 +77,22 @@ mod tests {
             .join("tests/fonts/source-sans/SourceSans3-Regular.ttf")
     }
 
+    fn glyph_id_for(path: &Path, codepoint: u32) -> u32 {
+        let data = map_font(path).unwrap();
+        let font = parse_font_ref(&data[..], path, 0).unwrap();
+        font.charmap().map(codepoint).unwrap().to_u32()
+    }
+
     #[test]
     fn loads_outline_without_python() {
-        let outline = load_glyph_outline(&test_font(), 0, 'A' as u32, None).unwrap();
+        let glyph_id = glyph_id_for(&test_font(), 'A' as u32);
+        let outline = load_glyph_outline(&test_font(), 0, glyph_id, None).unwrap();
         assert!(outline.subpaths().next().is_some());
     }
 
     #[test]
-    fn reports_missing_codepoint_as_out_of_range() {
-        let error = load_glyph_outline(&test_font(), 0, 0x10ffff, None).unwrap_err();
+    fn reports_missing_glyph_id_as_out_of_range() {
+        let error = load_glyph_outline(&test_font(), 0, u32::MAX, None).unwrap_err();
         assert!(matches!(error, Error::OutOfRange(_)));
     }
 }

--- a/tests/_glyphs.py
+++ b/tests/_glyphs.py
@@ -1,0 +1,17 @@
+"""Glyph id lookup for tests that build a :class:`torchfont.GlyphRef` by hand.
+
+``GlyphRef`` names a glyph by id. ``GlyphDataset`` resolves ids while indexing,
+so tests that skip the dataset resolve them here with fontTools instead.
+"""
+
+from __future__ import annotations
+
+from fontTools.ttLib import TTFont
+
+
+def glyph_id(path: str, char: str, ttc_index: int = 0) -> int:
+    """Return the glyph id one face maps ``char`` to."""
+    font = TTFont(path, fontNumber=ttc_index)
+    cmap = font.getBestCmap()
+    assert cmap is not None
+    return font.getGlyphID(cmap[ord(char)])

--- a/tests/google_fonts/test_merge_curves.py
+++ b/tests/google_fonts/test_merge_curves.py
@@ -48,7 +48,7 @@ def _transform(sample: GlyphSample) -> Tensor:
         logger.warning(
             "merge_curves bitmap mismatch: %s U+%04X",
             sample.ref.font.path,
-            sample.ref.codepoint,
+            sample.codepoint,
         )
     return failed
 

--- a/tests/google_fonts/test_random_remove_overlaps.py
+++ b/tests/google_fonts/test_random_remove_overlaps.py
@@ -28,7 +28,7 @@ def _hard_diff(a: Tensor, b: Tensor) -> Tensor:
 def _transform(sample: GlyphSample) -> Tensor:
     outline = _functional.load_glyph(sample.ref)
     types, coords = outline.types, outline.coords
-    torch.manual_seed(sample.ref.codepoint)
+    torch.manual_seed(sample.codepoint)
     simplified = RandomRemoveOverlaps()(Outline(types, coords))
     simplified_types, simplified_coords = simplified.types, simplified.coords
 
@@ -50,7 +50,7 @@ def _transform(sample: GlyphSample) -> Tensor:
         logger.warning(
             "random_remove_overlaps bitmap mismatch: %s U+%04X",
             sample.ref.font.path,
-            sample.ref.codepoint,
+            sample.codepoint,
         )
     changed = not (
         torch.equal(types, simplified_types) and torch.equal(coords, simplified_coords)

--- a/tests/google_fonts/test_remove_overlaps.py
+++ b/tests/google_fonts/test_remove_overlaps.py
@@ -120,7 +120,7 @@ def _transform(sample: GlyphSample) -> Tensor:
             "remove_overlaps failure [%s]: %s U+%04X",
             ",".join(reasons),
             sample.ref.font.path,
-            sample.ref.codepoint,
+            sample.codepoint,
         )
     return failed
 

--- a/tests/test_core_types.py
+++ b/tests/test_core_types.py
@@ -26,10 +26,10 @@ def test_core_types_are_exported_from_package_root() -> None:
     assert torchfont.Outline is Outline
 
 
-def test_glyph_ref_identifies_face_and_codepoint() -> None:
-    ref = GlyphRef(FontRef("font.ttf", 0), ord("A"))
+def test_glyph_ref_identifies_face_and_glyph() -> None:
+    ref = GlyphRef(FontRef("font.ttf", 0), 36)
 
-    assert ref.codepoint == ord("A")
+    assert ref.glyph_id == 36
 
 
 @pytest.mark.parametrize(
@@ -117,13 +117,14 @@ def test_outline_keeps_identity_equality() -> None:
 def test_glyph_data_keeps_identity_equality() -> None:
     types = torch.tensor([1, 6], dtype=torch.long)
     coords = torch.zeros((2, 6))
-    sample = GlyphSample(GlyphRef(FontRef("font.ttf", 0), 0x41), 0, 0)
+    sample = GlyphSample(GlyphRef(FontRef("font.ttf", 0), 36), 0x41, 0, 0)
 
     def build(outline: Outline) -> GlyphData[Outline]:
         return GlyphData(
             outline,
             sample.ref,
             {},
+            codepoint=sample.codepoint,
             font_idx=0,
             character_idx=0,
             weight=400.0,
@@ -141,12 +142,13 @@ def test_glyph_data_keeps_identity_equality() -> None:
 
 
 def test_glyph_data_targets_are_pytree_children() -> None:
-    ref = GlyphRef(FontRef("font.ttf", 0), 0x41)
+    ref = GlyphRef(FontRef("font.ttf", 0), 36)
     location = {"wght": 400.0}
     data = GlyphData(
         torch.tensor([1.0]),
         ref,
         location,
+        codepoint=0x41,
         font_idx=2,
         character_idx=3,
         weight=400.0,
@@ -159,15 +161,16 @@ def test_glyph_data_targets_are_pytree_children() -> None:
     leaves, spec = pytree.tree_flatten(data)
     rebuilt = pytree.tree_unflatten(leaves, spec)
 
-    assert leaves[1:] == [2, 3, 400.0, None, 0.0, None, 12.0]
+    assert leaves[1:] == [0x41, 2, 3, 400.0, None, 0.0, None, 12.0]
     assert rebuilt.ref is ref
     assert rebuilt.location is location
+    assert rebuilt.codepoint == 0x41
     assert rebuilt.font_idx == 2
     assert rebuilt.width is None
 
 
 def test_glyph_data_pytree_structure_does_not_depend_on_target_values() -> None:
-    ref = GlyphRef(FontRef("font.ttf", 0), 0x41)
+    ref = GlyphRef(FontRef("font.ttf", 0), 36)
     location: dict[str, float] = {}
 
     def make(weight: float | None) -> GlyphData[torch.Tensor]:
@@ -175,6 +178,7 @@ def test_glyph_data_pytree_structure_does_not_depend_on_target_values() -> None:
             torch.tensor([1.0]),
             ref,
             location,
+            codepoint=0x41,
             font_idx=0,
             character_idx=0,
             weight=weight,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -15,6 +15,7 @@ from torch.utils.data import DataLoader
 import torchfont
 import torchfont.datasets as datasets_module
 import torchfont.transforms as transforms_module
+from tests._glyphs import glyph_id
 from torchfont import (
     ElementType,
     FontRef,
@@ -77,7 +78,7 @@ def test_dataset_transform_receives_sample() -> None:
 
     def transform(sample: GlyphSample) -> int:
         seen.append(sample)
-        return sample.ref.codepoint
+        return sample.codepoint
 
     dataset = GlyphDataset(
         "tests/fonts",
@@ -106,6 +107,26 @@ def test_load_glyph_returns_outline_tensors() -> None:
     assert not (outline.types == ElementType.CURVE_TO.value).any().item()
 
 
+def test_dataset_resolves_glyph_ids_per_face() -> None:
+    path = "static-collection/Metropolis.ttc"
+    dataset = GlyphDataset("tests/fonts", patterns=path, codepoints=[ord("A")])
+
+    resolved = [dataset[idx].ref.glyph_id for idx in range(len(dataset))]
+
+    assert resolved == [
+        glyph_id(f"tests/fonts/{path}", "A", ttc_index)
+        for ttc_index in range(len(dataset.font_classes))
+    ]
+
+
+def test_load_glyph_reports_missing_glyph_id() -> None:
+    path = "tests/fonts/source-sans/SourceSans3-Regular.ttf"
+    ref = GlyphRef(FontRef(path, 0), 0xFFFF)
+
+    with pytest.raises(IndexError, match="glyph id 65535 missing"):
+        _functional.load_glyph(ref)
+
+
 def test_dataset_reports_corrupt_font(tmp_path: Path) -> None:
     (tmp_path / "broken.ttf").write_bytes(b"not a font")
 
@@ -114,7 +135,7 @@ def test_dataset_reports_corrupt_font(tmp_path: Path) -> None:
 
 
 def test_load_glyph_reports_missing_font(tmp_path: Path) -> None:
-    ref = GlyphRef(FontRef(str(tmp_path / "missing.ttf"), 0), ord("A"))
+    ref = GlyphRef(FontRef(str(tmp_path / "missing.ttf"), 0), 36)
 
     with pytest.raises(FileNotFoundError, match="failed to open"):
         _functional.load_glyph(ref)
@@ -260,6 +281,7 @@ def test_dataset_is_pickleable() -> None:
     restored_sample = restored[0]
     sample = dataset[0]
     assert restored_sample.ref == sample.ref
+    assert restored_sample.codepoint == sample.codepoint
     assert restored_sample.font_idx == sample.font_idx
     assert restored_sample.character_idx == sample.character_idx
     assert torch.equal(restored.font_targets, dataset.font_targets)
@@ -284,6 +306,7 @@ def test_dataset_accepts_negative_index() -> None:
     negative = dataset[-1]
     positive = dataset[1]
     assert negative.ref == positive.ref
+    assert negative.codepoint == positive.codepoint
     assert negative.font_idx == positive.font_idx
     assert negative.character_idx == positive.character_idx
 
@@ -389,7 +412,7 @@ def test_targets_match_samples_across_faces_with_unequal_coverage() -> None:
         sample = dataset[idx]
         assert font_targets[idx] == sample.font_idx
         assert character_targets[idx] == sample.character_idx
-        assert character_class_to_idx[chr(sample.ref.codepoint)] == sample.character_idx
+        assert character_class_to_idx[chr(sample.codepoint)] == sample.character_idx
         assert load(sample).data.types.numel() > 0
         coverage[sample.font_idx] = (
             *coverage.get(sample.font_idx, ()),
@@ -429,6 +452,7 @@ def test_patterns_accept_string_or_sequence() -> None:
     string_sample = string[0]
     sequence_sample = sequence[0]
     assert string_sample.ref == sequence_sample.ref
+    assert string_sample.codepoint == sequence_sample.codepoint
     assert string_sample.font_idx == sequence_sample.font_idx
     assert string_sample.character_idx == sequence_sample.character_idx
 
@@ -440,4 +464,4 @@ def test_codepoints_are_normalized_and_deduplicated() -> None:
         patterns="source-sans/SourceSans3-Regular.ttf",
         codepoints=codepoints,
     )
-    assert [dataset[i].ref.codepoint for i in range(len(dataset))] == [0x41, 0x42]
+    assert [dataset[i].codepoint for i in range(len(dataset))] == [0x41, 0x42]

--- a/tests/transforms/test_torchvision_interop.py
+++ b/tests/transforms/test_torchvision_interop.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from tests._glyphs import glyph_id
 from torchfont import FontRef, GlyphData, GlyphRef, GlyphSample
 from torchfont.transforms import (
     Compose,
@@ -13,11 +14,12 @@ tv_tensors = pytest.importorskip("torchvision.tv_tensors")
 v2 = pytest.importorskip("torchvision.transforms.v2")
 
 FONT = "tests/fonts/source-serif/SourceSerif4Variable-Roman.ttf"
+GLYPH_A = glyph_id(FONT, "A")
 
 
 def _render() -> torch.Tensor:
     pipeline = Compose([LoadGlyph(), HorizontalFlip(), RenderBitmap(size=64)])
-    return pipeline(GlyphRef(FontRef(FONT, 0), ord("A")))
+    return pipeline(GlyphRef(FontRef(FONT, 0), GLYPH_A))
 
 
 def test_to_image_converts_bitmap_to_channel_first_tv_image() -> None:
@@ -41,8 +43,8 @@ def test_render_bitmap_returns_a_plain_tensor() -> None:
 
 
 def test_torchvision_pipeline_preserves_glyph_data_to_model_boundary() -> None:
-    ref = GlyphRef(FontRef(FONT, 0), ord("A"))
-    sample = GlyphSample(ref, font_idx=3, character_idx=5)
+    ref = GlyphRef(FontRef(FONT, 0), GLYPH_A)
+    sample = GlyphSample(ref, codepoint=ord("A"), font_idx=3, character_idx=5)
     pipeline = Compose(
         [
             LoadGlyph(),
@@ -58,6 +60,7 @@ def test_torchvision_pipeline_preserves_glyph_data_to_model_boundary() -> None:
 
     assert isinstance(out, GlyphData)
     assert out.ref is sample.ref
+    assert out.codepoint == sample.codepoint
     assert out.font_idx == sample.font_idx
     assert out.character_idx == sample.character_idx
     assert type(out.data) is torch.Tensor

--- a/tests/transforms/test_transform.py
+++ b/tests/transforms/test_transform.py
@@ -3,6 +3,7 @@ import pickle
 import pytest
 import torch
 
+from tests._glyphs import glyph_id
 from torchfont import (
     ElementType,
     FontRef,
@@ -232,11 +233,9 @@ def test_load_glyph_rejects_invalid_location_policy() -> None:
 
 
 def _glyph_sample() -> GlyphSample:
-    ref = GlyphRef(
-        FontRef("tests/fonts/source-sans/SourceSans3-Regular.ttf", 0),
-        ord("A"),
-    )
-    return GlyphSample(ref, 0, 0)
+    path = "tests/fonts/source-sans/SourceSans3-Regular.ttf"
+    ref = GlyphRef(FontRef(path, 0), glyph_id(path, "A"))
+    return GlyphSample(ref, ord("A"), 0, 0)
 
 
 def test_load_and_outline_transforms_preserve_glyph_metadata() -> None:
@@ -248,6 +247,7 @@ def test_load_and_outline_transforms_preserve_glyph_metadata() -> None:
     assert isinstance(output, GlyphData)
     assert isinstance(output.data, Outline)
     assert output.ref is sample.ref
+    assert output.codepoint == sample.codepoint
     assert output.font_idx == sample.font_idx
     assert output.character_idx == sample.character_idx
     assert output.weight == 400.0
@@ -270,11 +270,9 @@ def test_type_changing_transforms_preserve_generic_glyph_container() -> None:
 
 
 def test_load_glyph_returns_the_randomly_sampled_location() -> None:
-    ref = GlyphRef(
-        FontRef("tests/fonts/source-serif/SourceSerif4Variable-Roman.ttf", 0),
-        ord("A"),
-    )
-    sample = GlyphSample(ref, 0, 0)
+    path = "tests/fonts/source-serif/SourceSerif4Variable-Roman.ttf"
+    ref = GlyphRef(FontRef(path, 0), glyph_id(path, "A"))
+    sample = GlyphSample(ref, ord("A"), 0, 0)
 
     output = LoadGlyph(location="random")(sample)
 

--- a/torchfont/_glyph.py
+++ b/torchfont/_glyph.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 _TARGET_FIELDS = (
+    "codepoint",
     "font_idx",
     "character_idx",
     "weight",
@@ -27,6 +28,7 @@ _TARGET_FIELDS = (
 
 
 class _GlyphDataTargets(TypedDict):
+    codepoint: int
     font_idx: int
     character_idx: int
     weight: float | None
@@ -38,10 +40,10 @@ class _GlyphDataTargets(TypedDict):
 
 @dataclass(frozen=True)
 class GlyphRef:
-    """Reference to one glyph face and codepoint before choosing a location."""
+    """Reference to one glyph of one font face before choosing a location."""
 
     font: FontRef
-    codepoint: int
+    glyph_id: int
 
 
 @dataclass(frozen=True)
@@ -49,6 +51,7 @@ class GlyphSample:
     """Dataset-local sample for one font face and codepoint."""
 
     ref: GlyphRef
+    codepoint: int
     font_idx: int
     character_idx: int
 
@@ -67,6 +70,7 @@ class GlyphData(Generic[T]):
     data: T
     ref: GlyphRef
     location: dict[str, float]
+    codepoint: int
     font_idx: int
     character_idx: int
     weight: float | None
@@ -94,6 +98,7 @@ register_pytree_node(GlyphData, _flatten_glyph_data, _unflatten_glyph_data)
 
 def _glyph_data_targets(
     *,
+    codepoint: int,
     font_idx: int,
     character_idx: int,
     metrics: tuple[float, float, float, float, float],
@@ -105,6 +110,7 @@ def _glyph_data_targets(
     """
     weight, width, italic, slant, optical_size = metrics
     return {
+        "codepoint": codepoint,
         "font_idx": font_idx,
         "character_idx": character_idx,
         "weight": _optional_metric(weight),

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -63,11 +63,12 @@ def index_fonts(
     list[int],
     npt.NDArray[np.uint32],
     npt.NDArray[np.uint32],
+    npt.NDArray[np.uint32],
 ]: ...
 def load_glyph(
     path: str,
     ttc_index: int,
-    codepoint: int,
+    glyph_id: int,
     location: dict[str, float] | None = ...,
 ) -> tuple[np.ndarray, np.ndarray]: ...
 def variation_axes(

--- a/torchfont/datasets/_base.py
+++ b/torchfont/datasets/_base.py
@@ -28,14 +28,16 @@ class _BaseGlyphDataset(Dataset[T], Generic[T]):
 
     Samples are laid out face by face: face ``i`` owns the half-open sample
     range ``_offsets[i]:_offsets[i + 1]``, so ``_offsets`` holds one more
-    element than ``_font_refs`` and ends with the sample count. The codepoint
-    of sample ``s`` is ``_character_codepoints[_character_index[s]]``.
+    element than ``_font_refs`` and ends with the sample count. Sample ``s``
+    draws glyph ``_glyph_ids[s]``, whose codepoint is
+    ``_character_codepoints[_character_index[s]]``.
     """
 
     _font_refs: tuple[FontRef, ...]
     _offsets: tuple[int, ...]
     _character_codepoints: npt.NDArray[np.uint32]
     _character_index: npt.NDArray[np.uint32]
+    _glyph_ids: npt.NDArray[np.uint32]
 
     def __init__(
         self,
@@ -54,9 +56,11 @@ class _BaseGlyphDataset(Dataset[T], Generic[T]):
             offsets,
             self._character_codepoints,
             self._character_index,
+            self._glyph_ids,
         ) = _torchfont.index_fonts(str(self.root), self.codepoints, self.patterns)
         self._character_codepoints.flags.writeable = False
         self._character_index.flags.writeable = False
+        self._glyph_ids.flags.writeable = False
         self._font_refs = tuple(
             FontRef(path, ttc_index) for path, ttc_index in font_refs
         )

--- a/torchfont/datasets/_glyph.py
+++ b/torchfont/datasets/_glyph.py
@@ -76,8 +76,9 @@ class GlyphDataset(_BaseGlyphDataset[T], Generic[T]):
         sample = GlyphSample(
             ref=GlyphRef(
                 self._font_refs[font_idx],
-                int(self._character_codepoints[character_idx]),
+                int(self._glyph_ids[sample_idx]),
             ),
+            codepoint=int(self._character_codepoints[character_idx]),
             font_idx=font_idx,
             character_idx=character_idx,
         )

--- a/torchfont/transforms/_glyph.py
+++ b/torchfont/transforms/_glyph.py
@@ -47,6 +47,7 @@ class LoadGlyph(nn.Module):
             ref=ref,
             location=location,
             **_glyph_data_targets(
+                codepoint=inpt.codepoint,
                 font_idx=inpt.font_idx,
                 character_idx=inpt.character_idx,
                 metrics=metrics,

--- a/torchfont/transforms/functional/_glyph.py
+++ b/torchfont/transforms/functional/_glyph.py
@@ -28,7 +28,7 @@ def load_glyph(
     raw_types, raw_coords = _torchfont.load_glyph(
         ref.font.path,
         ref.font.ttc_index,
-        ref.codepoint,
+        ref.glyph_id,
         normalized_location,
     )
     return Outline._wrap(  # noqa: SLF001


### PR DESCRIPTION
## Summary

`GlyphRef` now names a glyph by its face-local **glyph id**. The codepoint moves to the glyph item side as a target on `GlyphSample` and `GlyphData`, alongside `font_idx` and `character_idx`.

```python
GlyphRef(font: FontRef, glyph_id: int)
GlyphSample(ref: GlyphRef, codepoint: int, font_idx: int, character_idx: int)
GlyphData(data, ref, location, codepoint, font_idx, character_idx, weight, ...)
```

`codepoint` is a pytree child like the other scalar targets, so a `collate_fn` can batch it with them.

## Changes

- `DiscoveredFont` keeps the glyph id it already resolved while walking the charmap, instead of discarding it.
- `FontIndex` gains a sample-ordered `glyph_ids` array; `index_fonts` returns it as a fifth array and `_BaseGlyphDataset` holds it read-only.
- `load_glyph_outline` drops the per-load charmap lookup and draws the glyph id directly. A glyph id absent from the face raises `IndexError` (previously that error reported an unmapped codepoint).
- Docs updated in `en`/`ja`: field tables, the `GlyphData` target list, and the two snippets that built a `GlyphRef` by hand.

Each face of a collection numbers its glyphs independently, so ids are resolved per face; a new test checks the `.ttc` fixture against fontTools.

## Note

No public codepoint-to-glyph-id API is added. Building a `GlyphRef` without the dataset requires knowing the glyph id. Tests that skip the dataset resolve one through `tests/_glyphs.py`.

## Testing

- `mise run check`
- `mise exec -- uv run --no-sync pytest tests` (381 passed, 12 skipped)
- `mise run docs-build`

Google Fonts tests were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)