### PR TITLE
Add a max_length filter to both datasets

### DIFF
--- a/docs/en/guide/basic/dataset.md
+++ b/docs/en/guide/basic/dataset.md
@@ -45,6 +45,19 @@ dataset = CodepointDataset(
 Duplicate codepoints are removed and the index is deterministic. Fonts that do
 not contain any requested outline glyph are omitted.
 
+## Filtering by sequence length
+
+`max_length` keeps only glyphs whose outline is at most that many elements long:
+
+```python
+dataset = CodepointDataset(
+    root="data/google/fonts",
+    max_length=128,
+)
+```
+
+Fonts left without a fitting glyph are omitted.
+
 ## Reaching glyphs no codepoint maps to
 
 `CodepointDataset` indexes what the `cmap` table maps, so ligatures, alternates, and
@@ -63,7 +76,7 @@ print(len(dataset.font_classes))
 Each element represents one font face and one glyph id, in ascending order and
 starting at `.notdef`. Glyph ids are face-local, so this dataset takes no
 `codepoints` filter and its samples carry no character target. `patterns`,
-`transform`, and `LoadGlyph` work exactly as they do above.
+`max_length`, `transform`, and `LoadGlyph` work exactly as they do above.
 
 ## Choosing variation locations
 

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -8,8 +8,8 @@ variation locations when loading outlines.
 
 | Dataset | One element per | Sample | Filters |
 |---|---|---|---|
-| `CodepointDataset` | face and codepoint | `GlyphSample` | `codepoints`, `patterns` |
-| `GlyphIdDataset` | face and glyph id | `GlyphIdSample` | `patterns` |
+| `CodepointDataset` | face and codepoint | `GlyphSample` | `codepoints`, `max_length`, `patterns` |
+| `GlyphIdDataset` | face and glyph id | `GlyphIdSample` | `max_length`, `patterns` |
 
 Without a transform, `dataset[i]` returns a pickle-friendly sample:
 
@@ -27,6 +27,7 @@ CodepointDataset(
     root: Path | str,
     *,
     codepoints: Sequence[SupportsIndex] | None = None,
+    max_length: SupportsIndex | None = None,
     patterns: str | Sequence[str] | None = None,
     transform: Callable[[GlyphSample], T] | None = None,
 )
@@ -64,6 +65,7 @@ application requires a different distribution.
 GlyphIdDataset(
     root: Path | str,
     *,
+    max_length: SupportsIndex | None = None,
     patterns: str | Sequence[str] | None = None,
     transform: Callable[[GlyphIdSample], T] | None = None,
 )
@@ -97,6 +99,18 @@ class indices to train against.
 
 The sampling distribution is proportional to the number of outline glyphs in
 each face.
+
+## Filtering by sequence length
+
+Both datasets take `max_length`. It keeps only glyphs whose outline is at most
+that many elements long.
+
+```python
+dataset = GlyphIdDataset(root="data/google/fonts", max_length=128)
+```
+
+Faces left without a fitting glyph are omitted, as they are for the other
+filters.
 
 ## Loading glyphs
 

--- a/docs/ja/guide/basic/dataset.md
+++ b/docs/ja/guide/basic/dataset.md
@@ -44,6 +44,19 @@ dataset = CodepointDataset(
 重複したコードポイントは除去され、インデックスは決定的に構築されます。指定した
 アウトライングリフを 1 つも持たないフォントは除外されます。
 
+## 系列長のフィルター
+
+`max_length` は、アウトラインの要素数が指定値以下のグリフだけを残します。
+
+```python
+dataset = CodepointDataset(
+    root="data/google/fonts",
+    max_length=128,
+)
+```
+
+条件を満たすグリフが 1 つも残らないフォントは除外されます。
+
 ## コードポイントから辿れないグリフの利用
 
 `CodepointDataset` は `cmap` テーブルの対応関係をインデックスするため、リガチャや異体字など
@@ -61,8 +74,8 @@ print(len(dataset.font_classes))
 
 各要素は、フォントフェイスとグリフ ID 1 つの組を表します。`.notdef` から始まり、グリフ ID の
 昇順に並びます。グリフ ID はフェイスごとのローカルな値なので、`codepoints` フィルターはなく、
-サンプルは文字のターゲットを持ちません。`patterns` と `transform`、`LoadGlyph` の使い方は
-上と同じです。
+サンプルは文字のターゲットを持ちません。`patterns` と `max_length`、`transform`、`LoadGlyph`
+の使い方は上と同じです。
 
 ## バリエーション位置の選択
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -8,8 +8,8 @@ TorchFont はローカルのフォントディレクトリを 2 通りにイン�
 
 | データセット | 1 要素の単位 | サンプル | フィルター |
 |---|---|---|---|
-| `CodepointDataset` | フェイスとコードポイント | `GlyphSample` | `codepoints`, `patterns` |
-| `GlyphIdDataset` | フェイスとグリフ ID | `GlyphIdSample` | `patterns` |
+| `CodepointDataset` | フェイスとコードポイント | `GlyphSample` | `codepoints`, `max_length`, `patterns` |
+| `GlyphIdDataset` | フェイスとグリフ ID | `GlyphIdSample` | `max_length`, `patterns` |
 
 `transform` を指定しない場合、`dataset[i]` は `pickle` 可能なサンプルを返します。
 
@@ -27,6 +27,7 @@ CodepointDataset(
     root: Path | str,
     *,
     codepoints: Sequence[SupportsIndex] | None = None,
+    max_length: SupportsIndex | None = None,
     patterns: str | Sequence[str] | None = None,
     transform: Callable[[GlyphSample], T] | None = None,
 )
@@ -63,6 +64,7 @@ PyTorch のサンプラーで学習時の重みを調整してください。
 GlyphIdDataset(
     root: Path | str,
     *,
+    max_length: SupportsIndex | None = None,
     patterns: str | Sequence[str] | None = None,
     transform: Callable[[GlyphIdSample], T] | None = None,
 )
@@ -94,6 +96,17 @@ dataset = GlyphIdDataset(
 ないため、学習ターゲットではなくサンプル選択のためのデータとして使ってください。
 
 サンプリング分布は各フェイスが収録するアウトライングリフ数に比例します。
+
+## 系列長のフィルター
+
+どちらのデータセットも `max_length` を受け取ります。アウトラインの要素数が指定値以下の
+グリフだけを残します。
+
+```python
+dataset = GlyphIdDataset(root="data/google/fonts", max_length=128)
+```
+
+条件を満たすグリフが 1 つも残らないフェイスは、他のフィルターと同様に除外されます。
 
 ## グリフのロード
 

--- a/src/dataset/discovered_font.rs
+++ b/src/dataset/discovered_font.rs
@@ -1,9 +1,14 @@
 use std::path::{Path, PathBuf};
 
-use skrifa::{MetadataProvider, raw::FileRef};
+use skrifa::{
+    GlyphId, MetadataProvider,
+    instance::{LocationRef, Size},
+    outline::{DrawSettings, OutlineGlyph},
+    raw::FileRef,
+};
 
 use crate::error::Error;
-use crate::font::map_font;
+use crate::font::{count_glyph_elements, map_font};
 
 /// One discovered face and the codepoint/glyph id pairs its `cmap` contributes.
 pub(crate) struct DiscoveredCodepoints {
@@ -21,9 +26,13 @@ pub(crate) struct DiscoveredGlyphs {
 }
 
 impl DiscoveredCodepoints {
-    pub(crate) fn from_file(path: &Path, filter: Option<&[u32]>) -> Result<Vec<Self>, Error> {
+    pub(crate) fn from_file(
+        path: &Path,
+        filter: Option<&[u32]>,
+        max_length: Option<usize>,
+    ) -> Result<Vec<Self>, Error> {
         read_faces(path, |ttc_index, font| {
-            Self::from_font(path, ttc_index, font, filter)
+            Self::from_font(path, ttc_index, font, filter, max_length)
         })
     }
 
@@ -40,34 +49,42 @@ impl DiscoveredCodepoints {
         ttc_index: u32,
         font: &skrifa::FontRef<'_>,
         filter: Option<&[u32]>,
-    ) -> Self {
+        max_length: Option<usize>,
+    ) -> Result<Self, Error> {
         let outline_glyphs = font.outline_glyphs();
-        let mut mappings: Vec<_> = font
-            .charmap()
-            .mappings()
-            .filter(|(codepoint, _)| {
-                filter.is_none_or(|values| values.binary_search(codepoint).is_ok())
-            })
-            .filter(|(_, glyph_id)| outline_glyphs.get(*glyph_id).is_some())
-            .collect();
+        let mut mappings = Vec::new();
+        for (codepoint, glyph_id) in font.charmap().mappings() {
+            if filter.is_some_and(|values| values.binary_search(&codepoint).is_err()) {
+                continue;
+            }
+            let Some(glyph) = outline_glyphs.get(glyph_id) else {
+                continue;
+            };
+            if let Some(max_length) = max_length
+                && !fits_max_length(path, ttc_index, glyph_id, &glyph, max_length)?
+            {
+                continue;
+            }
+            mappings.push((codepoint, glyph_id));
+        }
         mappings.sort_unstable_by_key(|entry| entry.0);
         let (codepoints, glyph_ids) = mappings
             .into_iter()
             .map(|(codepoint, glyph_id)| (codepoint, glyph_id.to_u32()))
             .unzip();
-        Self {
+        Ok(Self {
             path: path.to_path_buf(),
             ttc_index,
             codepoints,
             glyph_ids,
-        }
+        })
     }
 }
 
 impl DiscoveredGlyphs {
-    pub(crate) fn from_file(path: &Path) -> Result<Vec<Self>, Error> {
+    pub(crate) fn from_file(path: &Path, max_length: Option<usize>) -> Result<Vec<Self>, Error> {
         read_faces(path, |ttc_index, font| {
-            Self::from_font(path, ttc_index, font)
+            Self::from_font(path, ttc_index, font, max_length)
         })
     }
 
@@ -79,24 +96,58 @@ impl DiscoveredGlyphs {
         self.glyph_ids.len()
     }
 
-    fn from_font(path: &Path, ttc_index: u32, font: &skrifa::FontRef<'_>) -> Self {
-        let glyph_ids = font
-            .outline_glyphs()
-            .iter()
-            .map(|(glyph_id, _)| glyph_id.to_u32())
-            .collect();
-        Self {
+    fn from_font(
+        path: &Path,
+        ttc_index: u32,
+        font: &skrifa::FontRef<'_>,
+        max_length: Option<usize>,
+    ) -> Result<Self, Error> {
+        let mut glyph_ids = Vec::new();
+        for (glyph_id, glyph) in font.outline_glyphs().iter() {
+            if let Some(max_length) = max_length
+                && !fits_max_length(path, ttc_index, glyph_id, &glyph, max_length)?
+            {
+                continue;
+            }
+            glyph_ids.push(glyph_id.to_u32());
+        }
+        Ok(Self {
             path: path.to_path_buf(),
             ttc_index,
             glyph_ids,
-        }
+        })
     }
+}
+
+/// Whether the encoded sequence of one glyph fits within `max_length`.
+///
+/// The elements are counted at the face default location, where variations
+/// move points without changing how many elements a glyph draws.
+fn fits_max_length(
+    path: &Path,
+    ttc_index: u32,
+    glyph_id: GlyphId,
+    glyph: &OutlineGlyph<'_>,
+    max_length: usize,
+) -> Result<bool, Error> {
+    let length = count_glyph_elements(
+        glyph,
+        DrawSettings::unhinted(Size::unscaled(), LocationRef::default()),
+    )
+    .map_err(|err| {
+        Error::Parse(format!(
+            "failed to draw glyph id {} of '{}' (ttc_index {ttc_index}): {err}",
+            glyph_id.to_u32(),
+            path.display()
+        ))
+    })?;
+    Ok(length <= max_length)
 }
 
 /// Parses every face in one font file and builds one entry per face.
 fn read_faces<T>(
     path: &Path,
-    build: impl Fn(u32, &skrifa::FontRef<'_>) -> T,
+    build: impl Fn(u32, &skrifa::FontRef<'_>) -> Result<T, Error>,
 ) -> Result<Vec<T>, Error> {
     let mapped = map_font(path)?;
     let parsed = FileRef::new(&mapped[..])
@@ -111,7 +162,7 @@ fn read_faces<T>(
                     path.display()
                 ))
             })?;
-            Ok(build(ttc_index as u32, &font))
+            build(ttc_index as u32, &font)
         })
         .collect::<Result<Vec<_>, Error>>()?;
     if entries.is_empty() {

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -49,18 +49,31 @@ impl CodepointIndex {
             glyph_ids.extend(face_glyph_ids);
             offsets.push(i64::try_from(codepoints.len()).expect("Vec length fits in i64"));
         }
-        let mut character_codepoints = codepoints.clone();
-        character_codepoints.sort_unstable();
-        character_codepoints.dedup();
-        let mut character_index = Vec::with_capacity(codepoints.len());
-        for face in offsets.windows(2) {
-            let mut base = 0;
-            for &codepoint in &codepoints[face[0] as usize..face[1] as usize] {
-                base += character_codepoints[base..].partition_point(|&other| other < codepoint);
-                character_index
-                    .push(u32::try_from(base).expect("unique u32 codepoint index fits in u32"));
+        // Rank every codepoint through a table indexed by the codepoint itself.
+        // `skrifa` limits `cmap` codepoints to `char::MAX`, so the table costs
+        // at most a few megabytes, and sizing it from the codepoints present
+        // keeps every lookup in bounds.
+        let table_len = codepoints
+            .iter()
+            .copied()
+            .max()
+            .map_or(0, |highest| highest as usize + 1);
+        let mut ranks = vec![u32::MAX; table_len];
+        for &codepoint in &codepoints {
+            ranks[codepoint as usize] = 0;
+        }
+        let mut character_codepoints = Vec::new();
+        for (codepoint, rank) in ranks.iter_mut().enumerate() {
+            if *rank != u32::MAX {
+                *rank = u32::try_from(character_codepoints.len())
+                    .expect("unique u32 codepoint index fits in u32");
+                character_codepoints.push(codepoint as u32);
             }
         }
+        let character_index: Vec<u32> = codepoints
+            .iter()
+            .map(|&codepoint| ranks[codepoint as usize])
+            .collect();
         Self {
             fonts,
             offsets,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -3,7 +3,9 @@
 mod discovered_font;
 mod discovery;
 mod index;
+mod parallel;
 
 pub(crate) use discovered_font::{DiscoveredCodepoints, DiscoveredGlyphs};
 pub(crate) use discovery::{canonicalize_root, discover_font_files};
 pub(crate) use index::{CodepointIndex, GlyphIndex};
+pub(crate) use parallel::build_from_files;

--- a/src/dataset/parallel.rs
+++ b/src/dataset/parallel.rs
@@ -1,0 +1,89 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use crate::error::Error;
+
+/// Builds entries from font files on every available core, in file order.
+///
+/// Parsing one font file is independent of every other, so files are claimed
+/// from a shared cursor and their results are reordered afterwards. Font sizes
+/// differ by orders of magnitude, so claiming one file at a time balances the
+/// work far better than splitting the list into equal shares. The result is
+/// what running `build` over `files` sequentially would produce, including
+/// which file's error is reported.
+pub(crate) fn build_from_files<T: Send>(
+    files: &[PathBuf],
+    build: impl Fn(&Path) -> Result<Vec<T>, Error> + Sync,
+) -> Result<Vec<T>, Error> {
+    let threads = thread::available_parallelism().map_or(1, |count| count.get());
+    let cursor = AtomicUsize::new(0);
+    let mut built: Vec<(usize, Result<Vec<T>, Error>)> = thread::scope(|scope| {
+        let workers: Vec<_> = (0..threads.min(files.len()))
+            .map(|_| {
+                scope.spawn(|| {
+                    let mut local = Vec::new();
+                    loop {
+                        let index = cursor.fetch_add(1, Ordering::Relaxed);
+                        let Some(path) = files.get(index) else { break };
+                        local.push((index, build(path)));
+                    }
+                    local
+                })
+            })
+            .collect();
+        workers
+            .into_iter()
+            .flat_map(|worker| worker.join().expect("font file workers do not panic"))
+            .collect()
+    });
+    built.sort_unstable_by_key(|(index, _)| *index);
+    let mut entries = Vec::new();
+    for (_, result) in built {
+        entries.extend(result?);
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::error::Error;
+
+    use super::build_from_files;
+
+    fn numbered_files(count: usize) -> Vec<PathBuf> {
+        (0..count)
+            .map(|index| PathBuf::from(index.to_string()))
+            .collect()
+    }
+
+    fn number(path: &Path) -> usize {
+        path.to_str().unwrap().parse().unwrap()
+    }
+
+    #[test]
+    fn builds_entries_in_file_order() {
+        let files = numbered_files(1000);
+        let entries = build_from_files(&files, |path| Ok(vec![number(path)])).unwrap();
+        assert_eq!(entries, (0..1000).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn reports_the_error_of_the_first_failing_file() {
+        let files = numbered_files(1000);
+        let error = build_from_files(&files, |path| match number(path) {
+            index @ (100 | 500) => Err(Error::Parse(index.to_string())),
+            index => Ok(vec![index]),
+        })
+        .unwrap_err();
+        assert!(matches!(error, Error::Parse(message) if message == "100"));
+    }
+
+    #[test]
+    fn builds_an_empty_file_list() {
+        let entries = build_from_files(&[], |path| Ok(vec![number(path)])).unwrap();
+        assert!(entries.is_empty());
+    }
+}

--- a/src/font/extract.rs
+++ b/src/font/extract.rs
@@ -2,6 +2,48 @@ use skrifa::outline::{DrawError, DrawSettings, OutlineGlyph, OutlinePen};
 
 use crate::outline::{BezPath, Point};
 
+/// Counts the elements one glyph draws, guarding drawing calls made with no
+/// open subpath exactly as [`OutlineEncodingPen`] does so both pens agree.
+struct ElementCountingPen {
+    count: usize,
+    has_open_subpath: bool,
+}
+
+impl ElementCountingPen {
+    fn new() -> Self {
+        Self {
+            count: 0,
+            has_open_subpath: false,
+        }
+    }
+}
+
+impl OutlinePen for ElementCountingPen {
+    fn move_to(&mut self, _x: f32, _y: f32) {
+        self.count += 1;
+        self.has_open_subpath = true;
+    }
+
+    fn line_to(&mut self, _x: f32, _y: f32) {
+        self.count += usize::from(self.has_open_subpath);
+    }
+
+    fn quad_to(&mut self, _cx0: f32, _cy0: f32, _x: f32, _y: f32) {
+        self.count += usize::from(self.has_open_subpath);
+    }
+
+    fn curve_to(&mut self, _cx0: f32, _cy0: f32, _cx1: f32, _cy1: f32, _x: f32, _y: f32) {
+        self.count += usize::from(self.has_open_subpath);
+    }
+
+    fn close(&mut self) {
+        if self.has_open_subpath {
+            self.count += 1;
+            self.has_open_subpath = false;
+        }
+    }
+}
+
 struct OutlineEncodingPen {
     outline: BezPath,
     scale: f64,
@@ -61,6 +103,17 @@ impl OutlinePen for OutlineEncodingPen {
     }
 }
 
+/// Counts the encoded sequence elements of one glyph, including the trailing
+/// `End` marker, without building its outline.
+pub(crate) fn count_glyph_elements<'a>(
+    glyph: &OutlineGlyph<'a>,
+    settings: DrawSettings<'a>,
+) -> Result<usize, DrawError> {
+    let mut pen = ElementCountingPen::new();
+    glyph.draw(settings, &mut pen)?;
+    Ok(pen.count + 1)
+}
+
 pub(crate) fn extract_glyph_outline<'a>(
     glyph: &OutlineGlyph<'a>,
     settings: DrawSettings<'a>,
@@ -69,4 +122,38 @@ pub(crate) fn extract_glyph_outline<'a>(
     let mut pen = OutlineEncodingPen::new(units_per_em);
     glyph.draw(settings, &mut pen)?;
     Ok(pen.outline)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use skrifa::{
+        MetadataProvider as _,
+        instance::{LocationRef, Size},
+        outline::DrawSettings,
+        raw::TableProvider as _,
+    };
+
+    use crate::font::{map_font, parse_font_ref};
+    use crate::outline::encode;
+
+    use super::{count_glyph_elements, extract_glyph_outline};
+
+    #[test]
+    fn counts_the_elements_the_encoder_emits() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fonts/source-sans/SourceSans3-Regular.ttf");
+        let data = map_font(&path).unwrap();
+        let font = parse_font_ref(&data[..], &path, 0).unwrap();
+        let units_per_em = f32::from(font.head().unwrap().units_per_em());
+        let settings = || DrawSettings::unhinted(Size::unscaled(), LocationRef::default());
+        for (_, glyph) in font.outline_glyphs().iter() {
+            let outline = extract_glyph_outline(&glyph, settings(), units_per_em).unwrap();
+            assert_eq!(
+                count_glyph_elements(&glyph, settings()).unwrap(),
+                encode(&outline).0.len()
+            );
+        }
+    }
 }

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -4,6 +4,6 @@ mod location;
 mod registered_axes;
 
 pub(crate) use data::{map_font, parse_font_ref};
-pub(crate) use extract::extract_glyph_outline;
+pub(crate) use extract::{count_glyph_elements, extract_glyph_outline};
 pub(crate) use location::{Location, axis_info, canonicalize_location};
 pub(crate) use registered_axes::registered_axis_values;

--- a/src/py/dataset/index.rs
+++ b/src/py/dataset/index.rs
@@ -4,8 +4,8 @@ use numpy::{IntoPyArray as _, PyArray1};
 use pyo3::{Py, PyResult, Python, pyfunction};
 
 use crate::dataset::{
-    CodepointIndex, DiscoveredCodepoints, DiscoveredGlyphs, GlyphIndex, canonicalize_root,
-    discover_font_files,
+    CodepointIndex, DiscoveredCodepoints, DiscoveredGlyphs, GlyphIndex, build_from_files,
+    canonicalize_root, discover_font_files,
 };
 
 type CodepointIndexArrays = (
@@ -23,10 +23,11 @@ pub(super) fn index_codepoints(
     py: Python<'_>,
     root: &str,
     codepoints: Option<Vec<u32>>,
+    max_length: Option<usize>,
     patterns: Option<Vec<String>>,
 ) -> PyResult<CodepointIndexArrays> {
     let index = py.detach(|| {
-        let fonts = discover_codepoint_fonts(root, codepoints, patterns)?;
+        let fonts = discover_codepoint_fonts(root, codepoints, max_length, patterns)?;
         Ok::<_, pyo3::PyErr>(CodepointIndex::build(
             fonts
                 .into_iter()
@@ -51,10 +52,11 @@ pub(super) fn index_codepoints(
 pub(super) fn index_glyphs(
     py: Python<'_>,
     root: &str,
+    max_length: Option<usize>,
     patterns: Option<Vec<String>>,
 ) -> PyResult<GlyphIndexArrays> {
     let index = py.detach(|| {
-        let fonts = discover_glyph_fonts(root, patterns)?;
+        let fonts = discover_glyph_fonts(root, max_length, patterns)?;
         Ok::<_, pyo3::PyErr>(GlyphIndex::build(
             fonts
                 .into_iter()
@@ -72,6 +74,7 @@ pub(super) fn index_glyphs(
 fn discover_codepoint_fonts(
     root: &str,
     codepoints: Option<Vec<u32>>,
+    max_length: Option<usize>,
     patterns: Option<Vec<String>>,
 ) -> PyResult<Vec<DiscoveredCodepoints>> {
     let filter = codepoints.map(|mut values| {
@@ -80,29 +83,28 @@ fn discover_codepoint_fonts(
         values
     });
     let root = canonicalize_root(root)?;
-    let mut entries = Vec::new();
-    for path in discover_font_files(&root, patterns.as_deref())? {
-        entries.extend(
-            DiscoveredCodepoints::from_file(&path, filter.as_deref())?
+    let files = discover_font_files(&root, patterns.as_deref())?;
+    Ok(build_from_files(&files, |path| {
+        Ok(
+            DiscoveredCodepoints::from_file(path, filter.as_deref(), max_length)?
                 .into_iter()
-                .filter(|entry| entry.codepoint_count() > 0),
-        );
-    }
-    Ok(entries)
+                .filter(|entry| entry.codepoint_count() > 0)
+                .collect(),
+        )
+    })?)
 }
 
 fn discover_glyph_fonts(
     root: &str,
+    max_length: Option<usize>,
     patterns: Option<Vec<String>>,
 ) -> PyResult<Vec<DiscoveredGlyphs>> {
     let root = canonicalize_root(root)?;
-    let mut entries = Vec::new();
-    for path in discover_font_files(&root, patterns.as_deref())? {
-        entries.extend(
-            DiscoveredGlyphs::from_file(&path)?
-                .into_iter()
-                .filter(|entry| entry.glyph_count() > 0),
-        );
-    }
-    Ok(entries)
+    let files = discover_font_files(&root, patterns.as_deref())?;
+    Ok(build_from_files(&files, |path| {
+        Ok(DiscoveredGlyphs::from_file(path, max_length)?
+            .into_iter()
+            .filter(|entry| entry.glyph_count() > 0)
+            .collect())
+    })?)
 }

--- a/tests/test_codepoint_dataset.py
+++ b/tests/test_codepoint_dataset.py
@@ -465,3 +465,58 @@ def test_codepoints_are_normalized_and_deduplicated() -> None:
         codepoints=codepoints,
     )
     assert [dataset[i].codepoint for i in range(len(dataset))] == [0x41, 0x42]
+
+
+def test_max_length_keeps_only_short_glyph_sequences() -> None:
+    max_length = 12
+    patterns = "source-sans/SourceSans3-Regular.ttf"
+    codepoints = range(0x21, 0x7F)
+    full = CodepointDataset(
+        "tests/fonts",
+        patterns=patterns,
+        codepoints=codepoints,
+        transform=LoadGlyph(),
+    )
+    expected = [
+        (glyph.codepoint, glyph.ref.glyph_id)
+        for glyph in (full[i] for i in range(len(full)))
+        if glyph.data.num_elements <= max_length
+    ]
+    dataset = CodepointDataset(
+        "tests/fonts",
+        patterns=patterns,
+        codepoints=codepoints,
+        max_length=max_length,
+        transform=LoadGlyph(),
+    )
+
+    assert 0 < len(expected) < len(full)
+    assert [
+        (glyph.codepoint, glyph.ref.glyph_id)
+        for glyph in (dataset[i] for i in range(len(dataset)))
+    ] == expected
+
+
+def test_max_length_counts_the_end_element() -> None:
+    dataset = CodepointDataset(
+        "tests/fonts",
+        patterns="source-sans/SourceSans3-Regular.ttf",
+        max_length=1,
+        transform=LoadGlyph(),
+    )
+
+    assert len(dataset) > 0
+    assert all(
+        dataset[i].data.types.tolist() == [ElementType.END] for i in range(len(dataset))
+    )
+
+
+def test_max_length_below_every_glyph_is_empty() -> None:
+    dataset = CodepointDataset(
+        "tests/fonts",
+        patterns="source-sans/SourceSans3-Regular.ttf",
+        max_length=0,
+    )
+
+    assert len(dataset) == 0
+    assert dataset.font_classes == []

--- a/tests/test_glyph_id_dataset.py
+++ b/tests/test_glyph_id_dataset.py
@@ -219,3 +219,30 @@ def test_public_dataset_api_is_exported() -> None:
     assert torchfont.GlyphIdSample is GlyphIdSample
     assert torchfont.GlyphIdData is GlyphIdData
     assert hasattr(_torchfont, "index_glyphs")
+
+
+def test_max_length_keeps_only_short_glyph_sequences() -> None:
+    max_length = 12
+    full = GlyphIdDataset("tests/fonts", patterns=STATIC_FONT, transform=LoadGlyph())
+    expected = [
+        glyph.ref.glyph_id
+        for glyph in (full[i] for i in range(len(full)))
+        if glyph.data.num_elements <= max_length
+    ]
+    dataset = GlyphIdDataset(
+        "tests/fonts",
+        patterns=STATIC_FONT,
+        max_length=max_length,
+        transform=LoadGlyph(),
+    )
+
+    assert 0 < len(expected) < len(full)
+    assert dataset.glyph_ids.tolist() == expected
+    assert all(dataset[i].data.num_elements <= max_length for i in range(len(dataset)))
+
+
+def test_max_length_below_every_glyph_is_empty() -> None:
+    dataset = GlyphIdDataset("tests/fonts", patterns=STATIC_FONT, max_length=0)
+
+    assert len(dataset) == 0
+    assert dataset.font_classes == []

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -57,6 +57,7 @@ def tight_bbox(
 def index_codepoints(
     root: str,
     codepoints: Sequence[int] | None,
+    max_length: int | None,
     patterns: Sequence[str] | None,
 ) -> tuple[
     list[tuple[Path, int]],
@@ -67,6 +68,7 @@ def index_codepoints(
 ]: ...
 def index_glyphs(
     root: str,
+    max_length: int | None,
     patterns: Sequence[str] | None,
 ) -> tuple[
     list[tuple[Path, int]],

--- a/torchfont/datasets/_codepoint.py
+++ b/torchfont/datasets/_codepoint.py
@@ -17,6 +17,7 @@ from torchfont.datasets._utils import (
     font_targets_from_offsets,
     normalize_codepoints,
     normalize_index,
+    normalize_max_length,
     normalize_patterns,
 )
 
@@ -37,6 +38,9 @@ class CodepointDataset(Dataset[T], Generic[T]):
     alternates, are unreachable here; index them with
     :class:`~torchfont.datasets.GlyphIdDataset` instead.
 
+    ``max_length`` keeps only glyphs whose outline is at most that many elements
+    long.
+
     Samples are laid out face by face: face ``i`` owns the half-open sample
     range ``_offsets[i]:_offsets[i + 1]``, so ``_offsets`` holds one more
     element than ``_font_refs`` and ends with the sample count. Sample ``s``
@@ -56,6 +60,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         root: Path | str,
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
+        max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
         transform: None = None,
     ) -> None: ...
@@ -66,6 +71,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         root: Path | str,
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
+        max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
         transform: Callable[[GlyphSample], T],
     ) -> None: ...
@@ -75,6 +81,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         root: Path | str,
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
+        max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
         transform: Callable[[GlyphSample], T] | None = None,
     ) -> None:
@@ -82,13 +89,16 @@ class CodepointDataset(Dataset[T], Generic[T]):
         self.transform = transform
         self.patterns = normalize_patterns(patterns)
         self.codepoints = normalize_codepoints(codepoints)
+        self.max_length = normalize_max_length(max_length)
         (
             font_refs,
             offsets,
             self._character_codepoints,
             self._character_index,
             self._glyph_ids,
-        ) = _torchfont.index_codepoints(str(self.root), self.codepoints, self.patterns)
+        ) = _torchfont.index_codepoints(
+            str(self.root), self.codepoints, self.max_length, self.patterns
+        )
         self._character_codepoints.flags.writeable = False
         self._character_index.flags.writeable = False
         self._glyph_ids.flags.writeable = False

--- a/torchfont/datasets/_glyph_id.py
+++ b/torchfont/datasets/_glyph_id.py
@@ -16,6 +16,7 @@ from torchfont._glyph import GlyphIdSample, GlyphRef
 from torchfont.datasets._utils import (
     font_targets_from_offsets,
     normalize_index,
+    normalize_max_length,
     normalize_patterns,
 )
 
@@ -35,6 +36,9 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
     including ligatures, alternates, and other glyphs no codepoint maps to.
     Glyph ids are face-local, so samples carry no character target.
 
+    ``max_length`` keeps only glyphs whose outline is at most that many elements
+    long.
+
     Samples are laid out face by face: face ``i`` owns the half-open sample
     range ``_offsets[i]:_offsets[i + 1]``, so ``_offsets`` holds one more
     element than ``_font_refs`` and ends with the sample count. Sample ``s``
@@ -50,6 +54,7 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
         self: GlyphIdDataset[GlyphIdSample],
         root: Path | str,
         *,
+        max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
         transform: None = None,
     ) -> None: ...
@@ -59,6 +64,7 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
         self: GlyphIdDataset[T],
         root: Path | str,
         *,
+        max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
         transform: Callable[[GlyphIdSample], T],
     ) -> None: ...
@@ -67,14 +73,16 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
         self,
         root: Path | str,
         *,
+        max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
         transform: Callable[[GlyphIdSample], T] | None = None,
     ) -> None:
         self.root = Path(root).expanduser().resolve()
         self.transform = transform
         self.patterns = normalize_patterns(patterns)
+        self.max_length = normalize_max_length(max_length)
         (font_refs, offsets, self._glyph_ids) = _torchfont.index_glyphs(
-            str(self.root), self.patterns
+            str(self.root), self.max_length, self.patterns
         )
         self._glyph_ids.flags.writeable = False
         self._font_refs = tuple(

--- a/torchfont/datasets/_utils.py
+++ b/torchfont/datasets/_utils.py
@@ -32,6 +32,12 @@ def normalize_codepoints(
     return tuple(sorted({index(codepoint) for codepoint in codepoints}))
 
 
+def normalize_max_length(max_length: SupportsIndex | None) -> int | None:
+    if max_length is None:
+        return None
+    return index(max_length)
+
+
 def normalize_index(idx: SupportsIndex, dataset_len: int) -> int:
     resolved_idx = index(idx)
     original_idx = resolved_idx


### PR DESCRIPTION
`CodepointDataset` and `GlyphIdDataset` take a `max_length` argument that keeps
only the glyphs whose outline encodes to at most that many elements, counting
the trailing `END` marker. This bounds a dataset to the sequence length a model
takes, in the same layer as the `codepoints` and `patterns` filters.

```python
dataset = GlyphIdDataset(root="data/google/fonts", max_length=128)
```

## Indexing speed

Counting an element sequence means drawing every candidate glyph, so this would
have made indexing five times slower. Two changes more than pay for it, and
both also speed up indexing without the filter.

- Font files are processed on every available core through scoped threads. Files
  are claimed from a shared cursor, since font sizes differ by orders of
  magnitude and equal shares leave one worker with the CJK faces. Results are
  reordered afterwards, so the index and the reported error are identical to a
  sequential build.
- `CodepointIndex::build` ranks codepoints through a table indexed by the
  codepoint instead of sorting every sample. Once discovery was parallel, that
  sort was the slower half of indexing.

Indexing the Google Fonts corpus (3792 files, 6.5M glyphs):

| | before | after |
|---|---|---|
| `CodepointDataset` | 0.80s | 0.09s |
| `CodepointDataset(max_length=128)` | 4.11s | 0.23s |
| `GlyphIdDataset` | 0.72s | 0.09s |
| `GlyphIdDataset(max_length=128)` | 4.18s | 0.27s |

## Scope

`max_length` bounds what the index contains. Transforms that add elements, such
as `RemoveOverlaps`, can still push a sample past it: over the whole corpus at
`max_length=256`, 0.22% of samples exceed 256 after `RemoveOverlaps` followed by
`QuadToCubic`, and 0.031% with `merge_curves=True`. Handle that where the batch
is built, the way variable sequence lengths are handled elsewhere.

## Testing

- `mise run check`, `mise run test` (406 passed)
- `pytest tests/google_fonts --google-fonts` (3 passed)
- Verified over the Google Fonts corpus that the index is byte-identical across
  runs and that every character target still matches its sample's codepoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)