### PR TITLE
Rename GlyphSample and GlyphData after their dataset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ mise run data-sync
 
 Transform modules are organized by font-domain responsibility:
 
-- `torchfont` exports core semantic values such as `Outline` and `GlyphData`.
+- `torchfont` exports core semantic values such as `Outline` and `CodepointData`.
   Rasterized glyphs remain plain tensors and enter image semantics explicitly
   through TorchVision.
 - `torchfont.transforms._transform` contains only the transform engine, while

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ pip install torchfont
 ```python
 from torch.utils.data import DataLoader
 
-from torchfont import GlyphData, Outline, pad_outlines
+from torchfont import CodepointData, Outline, pad_outlines
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(samples: list[GlyphData[Outline]]) -> Outline:
+def collate_fn(samples: list[CodepointData[Outline]]) -> Outline:
     return pad_outlines([sample.data for sample in samples])
 
 

--- a/docs/en/guide/advanced/multiprocessing.md
+++ b/docs/en/guide/advanced/multiprocessing.md
@@ -16,14 +16,14 @@ import torch
 from tqdm import tqdm
 from torch.utils.data import DataLoader
 
-from torchfont import GlyphData, Outline, pad_outlines
+from torchfont import CodepointData, Outline, pad_outlines
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import LoadGlyph
 
 MAX_ELEMENTS = 512
 
 
-def collate_fn(samples: list[GlyphData[Outline]]):
+def collate_fn(samples: list[CodepointData[Outline]]):
     return {
         "outline": pad_outlines([sample.data[:MAX_ELEMENTS] for sample in samples]),
         "font_idx": torch.tensor(

--- a/docs/en/guide/advanced/torchvision.md
+++ b/docs/en/guide/advanced/torchvision.md
@@ -136,7 +136,7 @@ dimension, and `T.ToDtype(..., scale=True)` converts pixel values from
 `[0, 255]` to `[0, 1]`. `T.ToPureTensor` removes the TorchVision image wrapper at
 the model boundary.
 
-The pipeline preserves the `GlyphData` metadata and replaces only its `data`
+The pipeline preserves the `CodepointData` metadata and replaces only its `data`
 payload. A local `collate_fn` can stack the image payloads and select the targets
 required by the model:
 

--- a/docs/en/guide/advanced/variable-fonts.md
+++ b/docs/en/guide/advanced/variable-fonts.md
@@ -32,8 +32,8 @@ print(sample.location)  # For example: {"wght": 573.2, "opsz": 41.7}
 ```
 
 The sampled values use PyTorch's random number generator, so DataLoader worker
-seeding and `torch.manual_seed` apply. `GlyphData.location` records the actual
-axis values used for the returned outline. On a static font it is an empty
+seeding and `torch.manual_seed` apply. `CodepointData.location` records the
+actual axis values used for the returned outline. On a static font it is an empty
 dictionary, and the random policy produces the same outline as the default
 policy.
 

--- a/docs/en/guide/basic/dataloader.md
+++ b/docs/en/guide/basic/dataloader.md
@@ -8,7 +8,7 @@ and parallel loading.
 
 ## Define a `transform`
 
-`GlyphSample` carries a glyph reference and target indices. Use `LoadGlyph` as
+`CodepointSample` carries a glyph reference and target indices. Use `LoadGlyph` as
 the first pipeline transform to load its semantic `Outline` while retaining the
 sample metadata.
 
@@ -17,7 +17,7 @@ transformation to each item. Pass `LoadGlyph()` directly and verify the output:
 
 ```python
 from torchfont.datasets import CodepointDataset
-from torchfont import GlyphData, Outline
+from torchfont import CodepointData, Outline
 from torchfont.transforms import LoadGlyph
 
 
@@ -32,13 +32,13 @@ dataset = CodepointDataset(
     transform=LoadGlyph(),
 )
 
-data: GlyphData[Outline] = dataset[0]
+data: CodepointData[Outline] = dataset[0]
 
 print(data.data.shape)
 print(data.data.coords.shape)
 ```
 
-With `LoadGlyph`, `dataset[0]` returns `GlyphData[Outline]`. Its `data` field is
+With `LoadGlyph`, `dataset[0]` returns `CodepointData[Outline]`. Its `data` field
 the outline, while its other fields retain the reference, location, and targets.
 The first shape is `(N,)` and the second is `(N, 6)`, where `N` varies by glyph.
 For example:
@@ -61,11 +61,11 @@ import torch
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import CodepointDataset
-from torchfont import GlyphData, Outline, pad_outlines
+from torchfont import CodepointData, Outline, pad_outlines
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(samples: list[GlyphData[Outline]]):
+def collate_fn(samples: list[CodepointData[Outline]]):
     return {
         "outline": pad_outlines([sample.data for sample in samples]),
         "font_idx": torch.tensor(

--- a/docs/en/guide/basic/glyph-data-format.md
+++ b/docs/en/guide/basic/glyph-data-format.md
@@ -37,7 +37,7 @@ print(data.slant)  # slant angle
 print(data.optical_size)  # optical size in points
 ```
 
-The return value is `GlyphData[Outline]`. It keeps the semantic outline,
+The return value is `CodepointData[Outline]`. It keeps the semantic outline,
 deterministic glyph reference, and dataset-local targets in one shallow record.
 Indices are Python integers and continuous targets are floats. A continuous
 target unavailable in the font is `None`. A training application's local

--- a/docs/en/reference/core-types.md
+++ b/docs/en/reference/core-types.md
@@ -6,13 +6,13 @@ Types for carrying font data through datasets and transform pipelines.
 
 ```python
 from torchfont import (
+    CodepointData,
+    CodepointSample,
     ElementType,
     FontRef,
-    GlyphData,
     GlyphIdData,
     GlyphIdSample,
     GlyphRef,
-    GlyphSample,
     Outline,
     pad_outlines,
     unpad_outlines,
@@ -80,10 +80,10 @@ Splits an `Outline` with exactly one batch dimension and removes trailing
 `ElementType.PAD` rows from each result. This is the explicit inverse of
 `pad_outlines`; use `Outline.unbind()` when padding must be preserved.
 
-### `GlyphData`
+### `CodepointData`
 
-`GlyphData` contains a transformed payload, glyph
-reference, resolved variation location, and the parallel `codepoint`,
+`CodepointData` contains a transformed payload, glyph reference, resolved
+variation location, and the parallel `codepoint`,
 `font_idx`, `character_idx`, `weight`, `width`, `italic`, `slant`, and
 `optical_size` targets. Unavailable continuous targets are `None`.
 
@@ -93,8 +93,8 @@ values used to load the glyph.
 Indices are Python integers and continuous targets are floats. An unavailable
 continuous target is `None`.
 
-`GlyphData` objects compare by identity. Compare tensor payloads explicitly when
-content equality is required.
+`CodepointData` objects compare by identity. Compare tensor payloads explicitly
+when content equality is required.
 
 Define a local `DataLoader.collate_fn` for the model's input contract and use
 [`pad_outlines`](#pad-outlines) when its payloads are variable-length outlines.
@@ -105,11 +105,11 @@ See [DataLoader](../guide/basic/dataloader.md).
 `GlyphIdData` is what `LoadGlyph` returns for a `GlyphIdSample`. It carries the
 same payload, glyph reference, resolved variation location, and `font_idx`,
 `weight`, `width`, `italic`, `slant`, and `optical_size` targets as
-`GlyphData`, without the `codepoint` and `character_idx` targets that a glyph
-no character maps to cannot have.
+`CodepointData`, without the `codepoint` and `character_idx` targets that a
+glyph no character maps to cannot have.
 
-It follows the same rules as `GlyphData`: identity equality, integer indices,
-and `None` for an unavailable continuous target.
+It follows the same rules as `CodepointData`: identity equality, integer
+indices, and `None` for an unavailable continuous target.
 
 ### `ElementType: IntEnum`
 

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -8,7 +8,7 @@ variation locations when loading outlines.
 
 | Dataset | One element per | Sample | Filters |
 |---|---|---|---|
-| `CodepointDataset` | face and codepoint | `GlyphSample` | `codepoints`, `max_length`, `patterns` |
+| `CodepointDataset` | face and codepoint | `CodepointSample` | `codepoints`, `max_length`, `patterns` |
 | `GlyphIdDataset` | face and glyph id | `GlyphIdSample` | `max_length`, `patterns` |
 
 Without a transform, `dataset[i]` returns a pickle-friendly sample:
@@ -17,7 +17,7 @@ Without a transform, `dataset[i]` returns a pickle-friendly sample:
 |---|---|
 | `FontRef` | `path: str`, `ttc_index: int` |
 | `GlyphRef` | `font: FontRef`, `glyph_id: int` |
-| `GlyphSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
+| `CodepointSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
 | `GlyphIdSample` | `ref: GlyphRef`, `font_idx: int` |
 
 ## `CodepointDataset`
@@ -29,7 +29,7 @@ CodepointDataset(
     codepoints: Sequence[SupportsIndex] | None = None,
     max_length: SupportsIndex | None = None,
     patterns: str | Sequence[str] | None = None,
-    transform: Callable[[GlyphSample], T] | None = None,
+    transform: Callable[[CodepointSample], T] | None = None,
 )
 ```
 
@@ -126,10 +126,11 @@ evaluation = CodepointDataset(root, transform=LoadGlyph())
 training = CodepointDataset(root, transform=LoadGlyph(location="random"))
 ```
 
-`LoadGlyph` returns a `GlyphData` for a `GlyphSample` and a `GlyphIdData` for a
-`GlyphIdSample`. Both carry the loaded payload, the glyph reference, the
-resolved location, and the continuous targets; only `GlyphData` carries the
-codepoint targets. See [Core Types](./core-types.md).
+`LoadGlyph` returns a `CodepointData` for a `CodepointSample` and a
+`GlyphIdData` for a `GlyphIdSample`. Both carry the loaded payload, the glyph
+reference, the resolved location, and the continuous targets; only
+`CodepointData` carries the codepoint targets. See
+[Core Types](./core-types.md).
 
 ## Loading explicit locations
 

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -7,11 +7,11 @@ image pipeline.
 ## Data types
 
 ```python
-from torchfont import GlyphData, GlyphIdData, Outline
+from torchfont import CodepointData, GlyphIdData, Outline
 ```
 
 `Outline(types, coords)` keeps the two coupled tensors together.
-`GlyphData[T]` keeps a transformed payload, glyph reference, variation location,
+`CodepointData[T]` keeps a transformed payload, glyph reference, variation location,
 and targets together. `GlyphIdData[T]` is its counterpart for glyph id samples,
 carrying the same fields without the codepoint targets. A pipeline can change
 either payload from `Outline` to a bitmap tensor without losing the other
@@ -40,8 +40,8 @@ data = transform(sample)
 outline = data.data
 ```
 
-`LoadGlyph` loads one `GlyphSample`, `GlyphIdSample`, or `GlyphRef`. A
-`GlyphSample` becomes `GlyphData[Outline]`, a `GlyphIdSample` becomes
+`LoadGlyph` loads one `CodepointSample`, `GlyphIdSample`, or `GlyphRef`. A
+`CodepointSample` becomes `CodepointData[Outline]`, a `GlyphIdSample` becomes
 `GlyphIdData[Outline]`, and a bare reference becomes `Outline`.
 `LoadGlyph` uses the face's default location unless `location="random"` is set.
 The random policy samples one location for any of these inputs and records it in
@@ -78,7 +78,7 @@ inside an already-applied transform.
 | Output | `RenderBitmap` |
 
 `RenderBitmap` changes each `Outline` leaf into a plain `uint8` tensor. When
-these leaves are inside `GlyphData` or `GlyphIdData`, its reference, location,
+these leaves are inside `CodepointData` or `GlyphIdData`, its reference, location,
 and targets remain alongside the converted payload.
 
 ### Using rendered glyphs with TorchVision
@@ -87,7 +87,7 @@ and targets remain alongside the converted payload.
 `torchvision.transforms.v2.ToImage()` as the boundary into an image pipeline:
 it adds the channel
 dimension and returns a `tv_tensors.Image` of shape `1 x H x W`. Fields in an
-enclosing `GlyphData` are preserved.
+enclosing `CodepointData` are preserved.
 `RenderBitmap(antialias=False)` produces binary edge coverage. This controls
 vector rasterization and is independent of the `antialias` option on a later
 `v2.Resize`, which controls image resampling.

--- a/docs/ja/guide/advanced/multiprocessing.md
+++ b/docs/ja/guide/advanced/multiprocessing.md
@@ -15,14 +15,14 @@ import torch
 from tqdm import tqdm
 from torch.utils.data import DataLoader
 
-from torchfont import GlyphData, Outline, pad_outlines
+from torchfont import CodepointData, Outline, pad_outlines
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import LoadGlyph
 
 MAX_ELEMENTS = 512
 
 
-def collate_fn(samples: list[GlyphData[Outline]]):
+def collate_fn(samples: list[CodepointData[Outline]]):
     return {
         "outline": pad_outlines([sample.data[:MAX_ELEMENTS] for sample in samples]),
         "font_idx": torch.tensor(

--- a/docs/ja/guide/advanced/torchvision.md
+++ b/docs/ja/guide/advanced/torchvision.md
@@ -135,7 +135,7 @@ print(sample.data.dtype)  # torch.float32
 追加し、`T.ToDtype(..., scale=True)` は画素値を `[0, 255]` から `[0, 1]` へ変換します。
 `T.ToPureTensor` はモデルへ渡す前に TorchVision の画像ラッパーを取り除きます。
 
-パイプラインは `GlyphData` のメタデータを維持し、`data` の内容だけを置き換えます。
+パイプラインは `CodepointData` のメタデータを維持し、`data` の内容だけを置き換えます。
 ローカルな `collate_fn` で画像テンソルをスタックし、モデルが必要とするターゲットを
 選択できます。
 

--- a/docs/ja/guide/advanced/variable-fonts.md
+++ b/docs/ja/guide/advanced/variable-fonts.md
@@ -33,7 +33,7 @@ print(sample.location)  # 例: {"wght": 573.2, "opsz": 41.7}
 
 サンプリングには PyTorch の乱数生成器が使われるため、DataLoader ワーカーのシードと
 `torch.manual_seed` が適用されます。返された `Outline` に実際に使用した軸の値は
-`GlyphData.location` に記録されます。静的フォントでは空の辞書となり、ランダム位置と
+`CodepointData.location` に記録されます。静的フォントでは空の辞書となり、ランダム位置と
 デフォルト位置では同じ `Outline` が返されます。
 
 `LoadGlyph(location="random")` はすべての軸をサンプリングします。実験で明示的な位置が

--- a/docs/ja/guide/basic/dataloader.md
+++ b/docs/ja/guide/basic/dataloader.md
@@ -9,7 +9,7 @@
 
 ## `transform` を定義する
 
-`GlyphSample` はグリフ参照とターゲットインデックスを持ちます。パイプラインの最初に
+`CodepointSample` はグリフ参照とターゲットインデックスを持ちます。パイプラインの最初に
 `LoadGlyph` を使うと、サンプルのメタデータを保持したまま意味型 `Outline` を読み込めます。
 
 `CodepointDataset` には、PyTorch のデータセットと同様にアイテムごとに変換を適用する
@@ -17,7 +17,7 @@
 
 ```python
 from torchfont.datasets import CodepointDataset
-from torchfont import GlyphData, Outline
+from torchfont import CodepointData, Outline
 from torchfont.transforms import LoadGlyph
 
 
@@ -32,13 +32,13 @@ dataset = CodepointDataset(
     transform=LoadGlyph(),
 )
 
-data: GlyphData[Outline] = dataset[0]
+data: CodepointData[Outline] = dataset[0]
 
 print(data.data.shape)
 print(data.data.coords.shape)
 ```
 
-`LoadGlyph` を渡すと、`dataset[0]` は `GlyphData[Outline]` を返します。`data` フィールドが
+`LoadGlyph` を渡すと、`dataset[0]` は `CodepointData[Outline]` を返します。`data` フィールドが
 `Outline` で、ほかのフィールドが参照、バリエーション位置、ターゲットを保持します。
 最初の shape は `(N,)`、次は `(N, 6)` で、`N` はグリフごとに異なります。
 例えば次のようになります。
@@ -61,11 +61,11 @@ import torch
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import CodepointDataset
-from torchfont import GlyphData, Outline, pad_outlines
+from torchfont import CodepointData, Outline, pad_outlines
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(samples: list[GlyphData[Outline]]):
+def collate_fn(samples: list[CodepointData[Outline]]):
     return {
         "outline": pad_outlines([sample.data for sample in samples]),
         "font_idx": torch.tensor(

--- a/docs/ja/guide/basic/glyph-data-format.md
+++ b/docs/ja/guide/basic/glyph-data-format.md
@@ -39,7 +39,7 @@ print(data.slant)  # 傾斜角度
 print(data.optical_size)  # ポイント単位のオプティカルサイズ
 ```
 
-返り値の `GlyphData[Outline]` は、意味型の `Outline`、決定的なグリフ参照、データセット
+返り値の `CodepointData[Outline]` は、意味型の `Outline`、決定的なグリフ参照、データセット
 固有のターゲットを 1 つの浅いレコードに保持します。
 
 インデックスは Python の整数、連続ターゲットは浮動小数点数です。フォントに存在しない

--- a/docs/ja/reference/core-types.md
+++ b/docs/ja/reference/core-types.md
@@ -6,13 +6,13 @@
 
 ```python
 from torchfont import (
+    CodepointData,
+    CodepointSample,
     ElementType,
     FontRef,
-    GlyphData,
     GlyphIdData,
     GlyphIdSample,
     GlyphRef,
-    GlyphSample,
     Outline,
     pad_outlines,
     unpad_outlines,
@@ -77,9 +77,9 @@ Batch 次元がちょうど一つの `Outline` を分割し、各結果の末尾
 `ElementType.PAD` 行を除去します。これは `pad_outlines` の明示的な逆操作です。
 Padding を保持する場合は `Outline.unbind()` を使います。
 
-### `GlyphData`
+### `CodepointData`
 
-`GlyphData` は変換後の Payload、Glyph 参照、Variation Location、
+`CodepointData` は変換後の Payload、Glyph 参照、Variation Location、
 並列な `codepoint`、`font_idx`、`character_idx`、`weight`、`width`、`italic`、
 `slant`、`optical_size` Target を保持します。取得できない連続 Target は `None` です。
 
@@ -89,7 +89,7 @@ Padding を保持する場合は `Outline.unbind()` を使います。
 Index は Python の整数、連続 Target は Float です。取得できない連続 Target は
 `None` になります。
 
-`GlyphData` 同士は同一性で比較されます。Tensor Payload の内容を比較する場合は、
+`CodepointData` 同士は同一性で比較されます。Tensor Payload の内容を比較する場合は、
 明示的な Tensor 比較を使ってください。
 
 モデルの入力契約に合わせてローカルな `DataLoader.collate_fn` を定義し、Payload が可変長 Outline の
@@ -98,13 +98,13 @@ Index は Python の整数、連続 Target は Float です。取得できない
 
 ### `GlyphIdData`
 
-`GlyphIdData` は `GlyphIdSample` に `LoadGlyph` を適用した結果です。`GlyphData` と同じ
+`GlyphIdData` は `GlyphIdSample` に `LoadGlyph` を適用した結果です。`CodepointData` と同じ
 Payload、Glyph 参照、Variation Location、`font_idx`、`weight`、`width`、`italic`、`slant`、
 `optical_size` Target を保持します。どの文字も対応しないグリフが持てない `codepoint` と
 `character_idx` の Target はありません。
 
 同一性による比較、Python の整数 Index、取得できない連続 Target が `None` になる点は
-`GlyphData` と同じです。
+`CodepointData` と同じです。
 
 ### `ElementType: IntEnum`
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -8,7 +8,7 @@ TorchFont はローカルのフォントディレクトリを 2 通りにイン�
 
 | データセット | 1 要素の単位 | サンプル | フィルター |
 |---|---|---|---|
-| `CodepointDataset` | フェイスとコードポイント | `GlyphSample` | `codepoints`, `max_length`, `patterns` |
+| `CodepointDataset` | フェイスとコードポイント | `CodepointSample` | `codepoints`, `max_length`, `patterns` |
 | `GlyphIdDataset` | フェイスとグリフ ID | `GlyphIdSample` | `max_length`, `patterns` |
 
 `transform` を指定しない場合、`dataset[i]` は `pickle` 可能なサンプルを返します。
@@ -17,7 +17,7 @@ TorchFont はローカルのフォントディレクトリを 2 通りにイン�
 |---|---|
 | `FontRef` | `path: str`, `ttc_index: int` |
 | `GlyphRef` | `font: FontRef`, `glyph_id: int` |
-| `GlyphSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
+| `CodepointSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
 | `GlyphIdSample` | `ref: GlyphRef`, `font_idx: int` |
 
 ## `CodepointDataset`
@@ -29,7 +29,7 @@ CodepointDataset(
     codepoints: Sequence[SupportsIndex] | None = None,
     max_length: SupportsIndex | None = None,
     patterns: str | Sequence[str] | None = None,
-    transform: Callable[[GlyphSample], T] | None = None,
+    transform: Callable[[CodepointSample], T] | None = None,
 )
 ```
 
@@ -121,9 +121,9 @@ evaluation = CodepointDataset(root, transform=LoadGlyph())
 training = CodepointDataset(root, transform=LoadGlyph(location="random"))
 ```
 
-`LoadGlyph` は `GlyphSample` に対しては `GlyphData` を、`GlyphIdSample` に対しては
+`LoadGlyph` は `CodepointSample` に対しては `CodepointData` を、`GlyphIdSample` に対しては
 `GlyphIdData` を返します。どちらもロードしたペイロード、グリフ参照、解決済みの位置、連続値の
-ターゲットを持ち、コードポイントのターゲットを持つのは `GlyphData` だけです。
+ターゲットを持ち、コードポイントのターゲットを持つのは `CodepointData` だけです。
 [基本型](./core-types.md) を参照してください。
 
 ## 明示的な位置のロード

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -6,11 +6,11 @@ TorchFont は Glyph の読み込み、変形、描画を組み合わせるため
 ## データ型
 
 ```python
-from torchfont import GlyphData, GlyphIdData, Outline
+from torchfont import CodepointData, GlyphIdData, Outline
 ```
 
 `Outline(types, coords)` は不可分な二つのテンソルを一つにまとめます。
-`GlyphData[T]` は変換中の Payload、Glyph 参照、Variation Location、Target を保持します。
+`CodepointData[T]` は変換中の Payload、Glyph 参照、Variation Location、Target を保持します。
 `GlyphIdData[T]` はグリフ ID の Sample に対応する型で、コードポイントの Target を除いた
 同じ Field を保持します。どちらも他の Field を失わずに、Payload を `Outline` から
 ビットマップテンソルへ変換できます。
@@ -38,8 +38,8 @@ data = transform(sample)
 outline = data.data
 ```
 
-`LoadGlyph` は一つの `GlyphSample`、`GlyphIdSample`、`GlyphRef` を読み込みます。
-`GlyphSample` は `GlyphData[Outline]` に、`GlyphIdSample` は `GlyphIdData[Outline]` に、
+`LoadGlyph` は一つの `CodepointSample`、`GlyphIdSample`、`GlyphRef` を読み込みます。
+`CodepointSample` は `CodepointData[Outline]` に、`GlyphIdSample` は `GlyphIdData[Outline]` に、
 参照単体は `Outline` になります。
 `LoadGlyph` は、`location="random"` を指定しない限り Face の Default Location を使います。
 Random Policy はいずれの入力に対しても位置を 1 点抽出し、返り値の `location` に保存します。
@@ -77,14 +77,14 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | 出力 | `RenderBitmap` |
 
 `RenderBitmap` は各 `Outline` を通常の `uint8` テンソルに変えます。これらが
-`GlyphData` や `GlyphIdData` の中にある場合も、参照、Location、Target は変換後の Payload と
+`CodepointData` や `GlyphIdData` の中にある場合も、参照、Location、Target は変換後の Payload と
 ともに維持されます。
 
 ### レンダリングしたグリフを TorchVision で使う
 
 `RenderBitmap` はグレースケールの通常の `H x W` テンソルを返します。
 `torchvision.transforms.v2.ToImage()` を画像パイプラインへの境界として使うと、チャンネル次元が追加され、
-形状が `1 x H x W` の `tv_tensors.Image` になります。外側の `GlyphData` の Field も
+形状が `1 x H x W` の `tv_tensors.Image` になります。外側の `CodepointData` の Field も
 維持されます。
 `RenderBitmap(antialias=False)` は Edge Coverage を二値化します。これは Vector の
 Rasterization を制御するもので、後段の `v2.Resize` における画像の Resampling を制御する

--- a/examples/torchvision_transform.py
+++ b/examples/torchvision_transform.py
@@ -8,13 +8,13 @@ from torch.utils.data import DataLoader
 from torchvision.transforms import v2 as T
 from tqdm import tqdm
 
-from torchfont import GlyphSample
+from torchfont import CodepointSample
 from torchfont import transforms as FT
 from torchfont.datasets import CodepointDataset
 from torchfont.glyphsets import LATIN_CORE
 
 if TYPE_CHECKING:
-    from torchfont import GlyphData, Outline
+    from torchfont import CodepointData, Outline
 
 
 class TransformPipeline(torch.nn.Module):
@@ -41,10 +41,10 @@ class TransformPipeline(torch.nn.Module):
         )
 
     def forward(
-        self, sample: GlyphSample
+        self, sample: CodepointSample
     ) -> tuple[Tensor, Tensor, Tensor, int, int, float | None]:
-        data = cast("GlyphData[Outline]", self.prepare_outline(sample))
-        image_data = cast("GlyphData[Tensor]", self.rasterize(data))
+        data = cast("CodepointData[Outline]", self.prepare_outline(sample))
+        image_data = cast("CodepointData[Tensor]", self.rasterize(data))
         return (
             data.data.types,
             data.data.coords,

--- a/examples/transform.py
+++ b/examples/transform.py
@@ -1,12 +1,12 @@
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from torchfont import GlyphData, Outline, pad_outlines
+from torchfont import CodepointData, Outline, pad_outlines
 from torchfont import transforms as T
 from torchfont.datasets import CodepointDataset
 
 
-def collate_fn(batch: list[GlyphData[Outline]]) -> Outline:
+def collate_fn(batch: list[CodepointData[Outline]]) -> Outline:
     return pad_outlines([data.data for data in batch])
 
 

--- a/tests/google_fonts/test_merge_curves.py
+++ b/tests/google_fonts/test_merge_curves.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from torch.utils.data import DataLoader
 
 from tests._pairs import merge_curves
-from torchfont import GlyphSample, Outline
+from torchfont import CodepointSample, Outline
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import functional as _functional
 from torchfont.transforms.functional import render_bitmap
@@ -25,7 +25,7 @@ def _hard_diff(a: Tensor, b: Tensor) -> Tensor:
     return ((a == 255) & (b == 0)) | ((a == 0) & (b == 255))
 
 
-def _transform(sample: GlyphSample) -> Tensor:
+def _transform(sample: CodepointSample) -> Tensor:
     outline = _functional.load_glyph(sample.ref)
     types, coords = outline.types, outline.coords
     merged_types, merged_coords = merge_curves(types, coords)

--- a/tests/google_fonts/test_random_remove_overlaps.py
+++ b/tests/google_fonts/test_random_remove_overlaps.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 from torch.utils.data import DataLoader
 
-from torchfont import ElementType, GlyphSample, Outline
+from torchfont import CodepointSample, ElementType, Outline
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import RandomRemoveOverlaps
 from torchfont.transforms import functional as _functional
@@ -25,7 +25,7 @@ def _hard_diff(a: Tensor, b: Tensor) -> Tensor:
     return ((a == 255) & (b == 0)) | ((a == 0) & (b == 255))
 
 
-def _transform(sample: GlyphSample) -> Tensor:
+def _transform(sample: CodepointSample) -> Tensor:
     outline = _functional.load_glyph(sample.ref)
     types, coords = outline.types, outline.coords
     torch.manual_seed(sample.codepoint)

--- a/tests/google_fonts/test_remove_overlaps.py
+++ b/tests/google_fonts/test_remove_overlaps.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from torch.utils.data import DataLoader
 
 from tests._pairs import remove_overlaps
-from torchfont import ElementType, GlyphSample, Outline
+from torchfont import CodepointSample, ElementType, Outline
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import functional as _functional
 from torchfont.transforms.functional import render_bitmap
@@ -69,7 +69,7 @@ def _hard_diff(a: Tensor, b: Tensor) -> Tensor:
     return ((a == 255) & (b == 0)) | ((a == 0) & (b == 255))
 
 
-def _transform(sample: GlyphSample) -> Tensor:
+def _transform(sample: CodepointSample) -> Tensor:
     outline = _functional.load_glyph(sample.ref)
     types, coords = outline.types, outline.coords
     simplified_types, simplified_coords = remove_overlaps(types, coords)

--- a/tests/test_codepoint_dataset.py
+++ b/tests/test_codepoint_dataset.py
@@ -17,11 +17,11 @@ import torchfont.datasets as datasets_module
 import torchfont.transforms as transforms_module
 from tests._glyphs import glyph_id
 from torchfont import (
+    CodepointData,
+    CodepointSample,
     ElementType,
     FontRef,
-    GlyphData,
     GlyphRef,
-    GlyphSample,
     Outline,
     _torchfont,
 )
@@ -33,12 +33,12 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-def _outline_pair(sample: GlyphSample) -> tuple[torch.Tensor, torch.Tensor]:
+def _outline_pair(sample: CodepointSample) -> tuple[torch.Tensor, torch.Tensor]:
     outline = LoadGlyph()(sample).data
     return outline.types, outline.coords
 
 
-def _worker_pair(sample: GlyphSample) -> tuple[torch.Tensor, torch.Tensor]:
+def _worker_pair(sample: CodepointSample) -> tuple[torch.Tensor, torch.Tensor]:
     outline = LoadGlyph(location="random")(sample).data
     return outline.types, outline.coords
 
@@ -55,7 +55,7 @@ def test_dataset_indexes_each_face_codepoint_once() -> None:
     assert dataset.character_targets.tolist() == [0, 1]
     assert dataset.character_classes == ["A", "B"]
     sample = dataset[0]
-    assert isinstance(sample, GlyphSample)
+    assert isinstance(sample, CodepointSample)
     assert isinstance(sample.ref, GlyphRef)
 
 
@@ -74,9 +74,9 @@ def test_dataset_treats_static_and_variable_files_as_one_face_each() -> None:
 
 
 def test_dataset_transform_receives_sample() -> None:
-    seen: list[GlyphSample] = []
+    seen: list[CodepointSample] = []
 
-    def transform(sample: GlyphSample) -> int:
+    def transform(sample: CodepointSample) -> int:
         seen.append(sample)
         return sample.codepoint
 
@@ -180,7 +180,7 @@ def test_load_glyph_uses_default_location() -> None:
 
     data = LoadGlyph()(dataset[0])
 
-    assert isinstance(data, GlyphData)
+    assert isinstance(data, CodepointData)
     assert isinstance(data.data, Outline)
     assert data.location == {"opsz": 20.0, "wght": 400.0}
 
@@ -274,7 +274,7 @@ def test_dataset_is_pickleable() -> None:
     )
 
     restored = cast(
-        "CodepointDataset[GlyphSample]",
+        "CodepointDataset[CodepointSample]",
         pickle.loads(pickle.dumps(dataset)),  # noqa: S301
     )
 
@@ -435,7 +435,7 @@ def test_dataset_repr() -> None:
 
 def test_public_dataset_api_is_exported() -> None:
     assert datasets_module.CodepointDataset is CodepointDataset
-    assert torchfont.GlyphSample is GlyphSample
+    assert torchfont.CodepointSample is CodepointSample
     assert transforms_module.LoadGlyph is LoadGlyph
     assert hasattr(_torchfont, "index_codepoints")
 

--- a/tests/test_core_types.py
+++ b/tests/test_core_types.py
@@ -6,13 +6,13 @@ import torchfont
 from torchfont import (
     COORD_DIM,
     TYPE_DIM,
+    CodepointData,
+    CodepointSample,
     ElementType,
     FontRef,
-    GlyphData,
     GlyphIdData,
     GlyphIdSample,
     GlyphRef,
-    GlyphSample,
     Outline,
 )
 
@@ -22,11 +22,11 @@ def test_core_types_are_exported_from_package_root() -> None:
     assert torchfont.TYPE_DIM == TYPE_DIM
     assert torchfont.ElementType is ElementType
     assert torchfont.FontRef is FontRef
-    assert torchfont.GlyphData is GlyphData
+    assert torchfont.CodepointData is CodepointData
     assert torchfont.GlyphIdData is GlyphIdData
     assert torchfont.GlyphIdSample is GlyphIdSample
     assert torchfont.GlyphRef is GlyphRef
-    assert torchfont.GlyphSample is GlyphSample
+    assert torchfont.CodepointSample is CodepointSample
     assert torchfont.Outline is Outline
 
 
@@ -121,10 +121,10 @@ def test_outline_keeps_identity_equality() -> None:
 def test_glyph_data_keeps_identity_equality() -> None:
     types = torch.tensor([1, 6], dtype=torch.long)
     coords = torch.zeros((2, 6))
-    sample = GlyphSample(GlyphRef(FontRef("font.ttf", 0), 36), 0x41, 0, 0)
+    sample = CodepointSample(GlyphRef(FontRef("font.ttf", 0), 36), 0x41, 0, 0)
 
-    def build(outline: Outline) -> GlyphData[Outline]:
-        return GlyphData(
+    def build(outline: Outline) -> CodepointData[Outline]:
+        return CodepointData(
             outline,
             sample.ref,
             {},
@@ -148,7 +148,7 @@ def test_glyph_data_keeps_identity_equality() -> None:
 def test_glyph_data_targets_are_pytree_children() -> None:
     ref = GlyphRef(FontRef("font.ttf", 0), 36)
     location = {"wght": 400.0}
-    data = GlyphData(
+    data = CodepointData(
         torch.tensor([1.0]),
         ref,
         location,
@@ -177,8 +177,8 @@ def test_glyph_data_pytree_structure_does_not_depend_on_target_values() -> None:
     ref = GlyphRef(FontRef("font.ttf", 0), 36)
     location: dict[str, float] = {}
 
-    def make(weight: float | None) -> GlyphData[torch.Tensor]:
-        return GlyphData(
+    def make(weight: float | None) -> CodepointData[torch.Tensor]:
+        return CodepointData(
             torch.tensor([1.0]),
             ref,
             location,

--- a/tests/transforms/test_torchvision_interop.py
+++ b/tests/transforms/test_torchvision_interop.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from tests._glyphs import glyph_id
-from torchfont import FontRef, GlyphData, GlyphRef, GlyphSample
+from torchfont import CodepointData, CodepointSample, FontRef, GlyphRef
 from torchfont.transforms import (
     Compose,
     HorizontalFlip,
@@ -44,7 +44,7 @@ def test_render_bitmap_returns_a_plain_tensor() -> None:
 
 def test_torchvision_pipeline_preserves_glyph_data_to_model_boundary() -> None:
     ref = GlyphRef(FontRef(FONT, 0), GLYPH_A)
-    sample = GlyphSample(ref, codepoint=ord("A"), font_idx=3, character_idx=5)
+    sample = CodepointSample(ref, codepoint=ord("A"), font_idx=3, character_idx=5)
     pipeline = Compose(
         [
             LoadGlyph(),
@@ -58,7 +58,7 @@ def test_torchvision_pipeline_preserves_glyph_data_to_model_boundary() -> None:
 
     out = pipeline(sample)
 
-    assert isinstance(out, GlyphData)
+    assert isinstance(out, CodepointData)
     assert out.ref is sample.ref
     assert out.codepoint == sample.codepoint
     assert out.font_idx == sample.font_idx

--- a/tests/transforms/test_transform.py
+++ b/tests/transforms/test_transform.py
@@ -5,11 +5,11 @@ import torch
 
 from tests._glyphs import glyph_id
 from torchfont import (
+    CodepointData,
+    CodepointSample,
     ElementType,
     FontRef,
-    GlyphData,
     GlyphRef,
-    GlyphSample,
     Outline,
 )
 from torchfont.transforms import (
@@ -232,10 +232,10 @@ def test_load_glyph_rejects_invalid_location_policy() -> None:
         LoadGlyph(location="invalid")  # ty: ignore[invalid-argument-type]
 
 
-def _glyph_sample() -> GlyphSample:
+def _glyph_sample() -> CodepointSample:
     path = "tests/fonts/source-sans/SourceSans3-Regular.ttf"
     ref = GlyphRef(FontRef(path, 0), glyph_id(path, "A"))
-    return GlyphSample(ref, ord("A"), 0, 0)
+    return CodepointSample(ref, ord("A"), 0, 0)
 
 
 def test_load_and_outline_transforms_preserve_glyph_metadata() -> None:
@@ -244,7 +244,7 @@ def test_load_and_outline_transforms_preserve_glyph_metadata() -> None:
 
     output = transform(sample)
 
-    assert isinstance(output, GlyphData)
+    assert isinstance(output, CodepointData)
     assert isinstance(output.data, Outline)
     assert output.ref is sample.ref
     assert output.codepoint == sample.codepoint
@@ -262,7 +262,7 @@ def test_type_changing_transforms_preserve_generic_glyph_container() -> None:
     sample = _glyph_sample()
     bitmap_output = Compose([LoadGlyph(), RenderBitmap(32)])(sample)
 
-    assert isinstance(bitmap_output, GlyphData)
+    assert isinstance(bitmap_output, CodepointData)
     assert type(bitmap_output.data) is torch.Tensor
     assert bitmap_output.data.shape == (32, 32)
     assert bitmap_output.ref is sample.ref
@@ -272,11 +272,11 @@ def test_type_changing_transforms_preserve_generic_glyph_container() -> None:
 def test_load_glyph_returns_the_randomly_sampled_location() -> None:
     path = "tests/fonts/source-serif/SourceSerif4Variable-Roman.ttf"
     ref = GlyphRef(FontRef(path, 0), glyph_id(path, "A"))
-    sample = GlyphSample(ref, ord("A"), 0, 0)
+    sample = CodepointSample(ref, ord("A"), 0, 0)
 
     output = LoadGlyph(location="random")(sample)
 
-    assert isinstance(output, GlyphData)
+    assert isinstance(output, CodepointData)
     assert isinstance(output.data, Outline)
     assert output.ref is sample.ref
     assert output.weight == output.location["wght"]

--- a/torchfont/__init__.py
+++ b/torchfont/__init__.py
@@ -32,11 +32,11 @@ Package Layout:
 
 from torchfont._font import FontRef
 from torchfont._glyph import (
-    GlyphData,
+    CodepointData,
+    CodepointSample,
     GlyphIdData,
     GlyphIdSample,
     GlyphRef,
-    GlyphSample,
 )
 from torchfont._outline import (
     COORD_DIM,
@@ -52,13 +52,13 @@ from . import datasets, glyphsets, nn, transforms
 __all__ = [
     "COORD_DIM",
     "TYPE_DIM",
+    "CodepointData",
+    "CodepointSample",
     "ElementType",
     "FontRef",
-    "GlyphData",
     "GlyphIdData",
     "GlyphIdSample",
     "GlyphRef",
-    "GlyphSample",
     "Outline",
     "datasets",
     "glyphsets",

--- a/torchfont/_glyph.py
+++ b/torchfont/_glyph.py
@@ -35,7 +35,7 @@ class GlyphRef:
 
 
 @dataclass(frozen=True)
-class GlyphSample:
+class CodepointSample:
     """Dataset-local sample for one font face and codepoint."""
 
     ref: GlyphRef
@@ -53,7 +53,7 @@ class GlyphIdSample:
 
 
 @dataclass(frozen=True, eq=False)
-class GlyphData(Generic[T]):
+class CodepointData(Generic[T]):
     """A loaded glyph payload together with its reference and targets.
 
     Indices are Python integers and continuous targets are floats. An unavailable
@@ -81,7 +81,7 @@ class GlyphIdData(Generic[T]):
     """A loaded glyph payload identified by glyph id rather than codepoint.
 
     Carries the same reference, location, and continuous targets as
-    :class:`GlyphData`, without the codepoint targets that a glyph no character
+    :class:`CodepointData`, without the codepoint targets that a glyph no character
     maps to cannot have.
     """
 
@@ -96,19 +96,21 @@ class GlyphIdData(Generic[T]):
     optical_size: float | None
 
 
-def _register_glyph_data(
-    cls: type[GlyphData[Any] | GlyphIdData[Any]],
+def _register_glyph_payload(
+    cls: type[CodepointData[Any] | GlyphIdData[Any]],
     target_fields: tuple[str, ...],
 ) -> None:
     """Register one payload class as a pytree whose targets are children."""
 
-    def flatten(value: GlyphData[Any] | GlyphIdData[Any]) -> tuple[list[Any], object]:
+    def flatten(
+        value: CodepointData[Any] | GlyphIdData[Any],
+    ) -> tuple[list[Any], object]:
         children = [value.data, *(getattr(value, name) for name in target_fields)]
         return children, (value.ref, value.location)
 
     def unflatten(
         children: Iterable[Any], context: tuple[Any, ...]
-    ) -> GlyphData[Any] | GlyphIdData[Any]:
+    ) -> CodepointData[Any] | GlyphIdData[Any]:
         data, *targets = children
         ref, location = context
         return cls(data, ref, location, *targets)
@@ -116,10 +118,10 @@ def _register_glyph_data(
     register_pytree_node(cls, flatten, unflatten)
 
 
-_register_glyph_data(
-    GlyphData, ("codepoint", "font_idx", "character_idx", *_METRIC_FIELDS)
+_register_glyph_payload(
+    CodepointData, ("codepoint", "font_idx", "character_idx", *_METRIC_FIELDS)
 )
-_register_glyph_data(GlyphIdData, ("font_idx", *_METRIC_FIELDS))
+_register_glyph_payload(GlyphIdData, ("font_idx", *_METRIC_FIELDS))
 
 
 def _metric_targets(
@@ -146,9 +148,9 @@ def _optional_metric(value: float) -> float | None:
 
 
 __all__ = [
-    "GlyphData",
+    "CodepointData",
+    "CodepointSample",
     "GlyphIdData",
     "GlyphIdSample",
     "GlyphRef",
-    "GlyphSample",
 ]

--- a/torchfont/datasets/_codepoint.py
+++ b/torchfont/datasets/_codepoint.py
@@ -12,7 +12,7 @@ from torch.utils.data import Dataset
 
 from torchfont import _torchfont
 from torchfont._font import FontRef
-from torchfont._glyph import GlyphRef, GlyphSample
+from torchfont._glyph import CodepointSample, GlyphRef
 from torchfont.datasets._utils import (
     font_targets_from_offsets,
     normalize_codepoints,
@@ -56,7 +56,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
 
     @overload
     def __init__(
-        self: CodepointDataset[GlyphSample],
+        self: CodepointDataset[CodepointSample],
         root: Path | str,
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
@@ -73,7 +73,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         codepoints: Sequence[SupportsIndex] | None = None,
         max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
-        transform: Callable[[GlyphSample], T],
+        transform: Callable[[CodepointSample], T],
     ) -> None: ...
 
     def __init__(
@@ -83,7 +83,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         codepoints: Sequence[SupportsIndex] | None = None,
         max_length: SupportsIndex | None = None,
         patterns: str | Sequence[str] | None = None,
-        transform: Callable[[GlyphSample], T] | None = None,
+        transform: Callable[[CodepointSample], T] | None = None,
     ) -> None:
         self.root = Path(root).expanduser().resolve()
         self.transform = transform
@@ -144,8 +144,8 @@ class CodepointDataset(Dataset[T], Generic[T]):
 
     @overload
     def __getitem__(
-        self: CodepointDataset[GlyphSample], idx: SupportsIndex
-    ) -> GlyphSample: ...
+        self: CodepointDataset[CodepointSample], idx: SupportsIndex
+    ) -> CodepointSample: ...
 
     @overload
     def __getitem__(self, idx: SupportsIndex) -> T: ...
@@ -156,7 +156,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         character_idx: int = self._character_index.item(sample_idx)
         glyph_id: int = self._glyph_ids.item(sample_idx)
         codepoint: int = self._character_codepoints.item(character_idx)
-        sample = GlyphSample(
+        sample = CodepointSample(
             ref=GlyphRef(self._font_refs[font_idx], glyph_id),
             codepoint=codepoint,
             font_idx=font_idx,

--- a/torchfont/transforms/_glyph.py
+++ b/torchfont/transforms/_glyph.py
@@ -9,11 +9,11 @@ from torch import nn
 
 from torchfont import _torchfont
 from torchfont._glyph import (
-    GlyphData,
+    CodepointData,
+    CodepointSample,
     GlyphIdData,
     GlyphIdSample,
     GlyphRef,
-    GlyphSample,
     _metric_targets,
 )
 from torchfont.transforms import functional as _functional
@@ -33,8 +33,8 @@ class LoadGlyph(nn.Module):
         self.location = location
 
     def forward(
-        self, inpt: GlyphSample | GlyphIdSample | GlyphRef
-    ) -> GlyphData | GlyphIdData | Outline:
+        self, inpt: CodepointSample | GlyphIdSample | GlyphRef
+    ) -> CodepointData | GlyphIdData | Outline:
         """Load the referenced glyph."""
         ref = inpt if isinstance(inpt, GlyphRef) else inpt.ref
         location = (
@@ -54,7 +54,7 @@ class LoadGlyph(nn.Module):
                 font_idx=inpt.font_idx,
                 **_metric_targets(metrics),
             )
-        return GlyphData(
+        return CodepointData(
             data=outline,
             ref=ref,
             location=location,


### PR DESCRIPTION
`CodepointDataset` yielded a `GlyphSample` that `LoadGlyph` turned into a
`GlyphData`, while `GlyphIdDataset` yielded a `GlyphIdSample` that became a
`GlyphIdData`. The codepoint types kept the names they had when the dataset was
called `GlyphDataset`, so only one of the two triples read consistently.

| Dataset | Sample | Loaded payload |
|---|---|---|
| `CodepointDataset` | `CodepointSample` | `CodepointData` |
| `GlyphIdDataset` | `GlyphIdSample` | `GlyphIdData` |

`GlyphRef` and `LoadGlyph` keep their names: they belong to neither dataset and
serve both.

## Testing

- `mise run check`, `mise run test` (406 passed), `npm run docs:build`