### PR TITLE
Rename FontRef.ttc_index to face_index

### DIFF
--- a/docs/en/guide/advanced/font-collections.md
+++ b/docs/en/guide/advanced/font-collections.md
@@ -15,12 +15,12 @@ dataset = CodepointDataset(
 )
 
 for font in dataset.font_classes:
-    print(font.path, font.ttc_index)
+    print(font.path, font.face_index)
 ```
 
-Each face receives its own `font_idx`. `FontRef.ttc_index` identifies the face
-within the file, beginning at zero; it is also zero for an ordinary single-face
-font. A collection face otherwise behaves like any other font in the dataset.
+Each face receives its own `font_idx`. `FontRef.face_index` identifies the face
+within the file, beginning at zero. A collection face otherwise behaves like any
+other font in the dataset.
 
 ## Selecting one face directly
 
@@ -31,14 +31,14 @@ from torchfont import FontRef, GlyphRef
 from torchfont.transforms import LoadGlyph
 
 ref = GlyphRef(
-    font=FontRef("data/fonts/example.ttc", ttc_index=2),
+    font=FontRef("data/fonts/example.ttc", face_index=2),
     glyph_id=36,
 )
 outline = LoadGlyph()(ref)
 ```
 
 An OpenType Collection may also contain variable faces. Face selection and
-variation-location selection are independent: `ttc_index` selects a face, then
+variation-location selection are independent: `face_index` selects a face, then
 `LoadGlyph(location="random")` samples that face's variation axes.
 
 See [Variable Fonts](./variable-fonts.md) for location sampling and explicit

--- a/docs/en/guide/basic/glyph-data-format.md
+++ b/docs/en/guide/basic/glyph-data-format.md
@@ -178,7 +178,7 @@ print(dataset.font_classes[sample.font_idx])
 You will see output like:
 
 ```
-FontRef(path='.../Aclonica-Regular.ttf', ttc_index=0)
+FontRef(path='.../Aclonica-Regular.ttf', face_index=0)
 ```
 
 ### `character_idx`

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -15,7 +15,7 @@ Without a transform, `dataset[i]` returns a pickle-friendly sample:
 
 | Type | Fields |
 |---|---|
-| `FontRef` | `path: str`, `ttc_index: int` |
+| `FontRef` | `path: str`, `face_index: int` |
 | `GlyphRef` | `font: FontRef`, `glyph_id: int` |
 | `CodepointSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
 | `GlyphIdSample` | `ref: GlyphRef`, `font_idx: int` |

--- a/docs/ja/guide/advanced/font-collections.md
+++ b/docs/ja/guide/advanced/font-collections.md
@@ -15,12 +15,12 @@ dataset = CodepointDataset(
 )
 
 for font in dataset.font_classes:
-    print(font.path, font.ttc_index)
+    print(font.path, font.face_index)
 ```
 
-各フェイスには個別の `font_idx` が割り当てられます。`FontRef.ttc_index` はファイル内の
-フェイスを 0 から始まる番号で表します。通常の単一フェイスフォントでは 0 です。
-それ以外の扱いは、データセット内のほかのフォントと同じです。
+各フェイスには個別の `font_idx` が割り当てられます。`FontRef.face_index` はファイル内の
+フェイスを 0 から始まる番号で表します。それ以外の扱いは、データセット内のほかの
+フォントと同じです。
 
 ## フェイスを直接選択する
 
@@ -31,14 +31,14 @@ from torchfont import FontRef, GlyphRef
 from torchfont.transforms import LoadGlyph
 
 ref = GlyphRef(
-    font=FontRef("data/fonts/example.ttc", ttc_index=2),
+    font=FontRef("data/fonts/example.ttc", face_index=2),
     glyph_id=36,
 )
 outline = LoadGlyph()(ref)
 ```
 
 OpenType Collection にはバリアブルフォントのフェイスを含めることもできます。フェイスと
-バリエーション位置は独立して選択されます。`ttc_index` でフェイスを選び、そのフェイスの
+バリエーション位置は独立して選択されます。`face_index` でフェイスを選び、そのフェイスの
 バリエーション軸を `LoadGlyph(location="random")` でサンプリングできます。
 
 位置のサンプリングと明示的な軸の値については、

--- a/docs/ja/guide/basic/glyph-data-format.md
+++ b/docs/ja/guide/basic/glyph-data-format.md
@@ -180,7 +180,7 @@ print(dataset.font_classes[sample.font_idx])
 実行すると次のような出力が得られます。
 
 ```
-FontRef(path='.../Aclonica-Regular.ttf', ttc_index=0)
+FontRef(path='.../Aclonica-Regular.ttf', face_index=0)
 ```
 
 ### `character_idx`

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -15,7 +15,7 @@ TorchFont はローカルのフォントディレクトリを 2 通りにイン�
 
 | 型 | フィールド |
 |---|---|
-| `FontRef` | `path: str`, `ttc_index: int` |
+| `FontRef` | `path: str`, `face_index: int` |
 | `GlyphRef` | `font: FontRef`, `glyph_id: int` |
 | `CodepointSample` | `ref: GlyphRef`, `codepoint: int`, `font_idx: int`, `character_idx: int` |
 | `GlyphIdSample` | `ref: GlyphRef`, `font_idx: int` |

--- a/src/dataset/discovered_font.rs
+++ b/src/dataset/discovered_font.rs
@@ -13,7 +13,7 @@ use crate::font::{count_glyph_elements, map_font};
 /// One discovered face and the codepoint/glyph id pairs its `cmap` contributes.
 pub(crate) struct DiscoveredCodepoints {
     path: PathBuf,
-    ttc_index: u32,
+    face_index: u32,
     codepoints: Vec<u32>,
     glyph_ids: Vec<u32>,
 }
@@ -21,7 +21,7 @@ pub(crate) struct DiscoveredCodepoints {
 /// One discovered face and every glyph id it draws an outline for.
 pub(crate) struct DiscoveredGlyphs {
     path: PathBuf,
-    ttc_index: u32,
+    face_index: u32,
     glyph_ids: Vec<u32>,
 }
 
@@ -31,13 +31,13 @@ impl DiscoveredCodepoints {
         filter: Option<&[u32]>,
         max_length: Option<usize>,
     ) -> Result<Vec<Self>, Error> {
-        read_faces(path, |ttc_index, font| {
-            Self::from_font(path, ttc_index, font, filter, max_length)
+        read_faces(path, |face_index, font| {
+            Self::from_font(path, face_index, font, filter, max_length)
         })
     }
 
     pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>, Vec<u32>) {
-        (self.path, self.ttc_index, self.codepoints, self.glyph_ids)
+        (self.path, self.face_index, self.codepoints, self.glyph_ids)
     }
 
     pub(crate) fn codepoint_count(&self) -> usize {
@@ -46,7 +46,7 @@ impl DiscoveredCodepoints {
 
     fn from_font(
         path: &Path,
-        ttc_index: u32,
+        face_index: u32,
         font: &skrifa::FontRef<'_>,
         filter: Option<&[u32]>,
         max_length: Option<usize>,
@@ -61,7 +61,7 @@ impl DiscoveredCodepoints {
                 continue;
             };
             if let Some(max_length) = max_length
-                && !fits_max_length(path, ttc_index, glyph_id, &glyph, max_length)?
+                && !fits_max_length(path, face_index, glyph_id, &glyph, max_length)?
             {
                 continue;
             }
@@ -74,7 +74,7 @@ impl DiscoveredCodepoints {
             .unzip();
         Ok(Self {
             path: path.to_path_buf(),
-            ttc_index,
+            face_index,
             codepoints,
             glyph_ids,
         })
@@ -83,13 +83,13 @@ impl DiscoveredCodepoints {
 
 impl DiscoveredGlyphs {
     pub(crate) fn from_file(path: &Path, max_length: Option<usize>) -> Result<Vec<Self>, Error> {
-        read_faces(path, |ttc_index, font| {
-            Self::from_font(path, ttc_index, font, max_length)
+        read_faces(path, |face_index, font| {
+            Self::from_font(path, face_index, font, max_length)
         })
     }
 
     pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>) {
-        (self.path, self.ttc_index, self.glyph_ids)
+        (self.path, self.face_index, self.glyph_ids)
     }
 
     pub(crate) fn glyph_count(&self) -> usize {
@@ -98,14 +98,14 @@ impl DiscoveredGlyphs {
 
     fn from_font(
         path: &Path,
-        ttc_index: u32,
+        face_index: u32,
         font: &skrifa::FontRef<'_>,
         max_length: Option<usize>,
     ) -> Result<Self, Error> {
         let mut glyph_ids = Vec::new();
         for (glyph_id, glyph) in font.outline_glyphs().iter() {
             if let Some(max_length) = max_length
-                && !fits_max_length(path, ttc_index, glyph_id, &glyph, max_length)?
+                && !fits_max_length(path, face_index, glyph_id, &glyph, max_length)?
             {
                 continue;
             }
@@ -113,7 +113,7 @@ impl DiscoveredGlyphs {
         }
         Ok(Self {
             path: path.to_path_buf(),
-            ttc_index,
+            face_index,
             glyph_ids,
         })
     }
@@ -125,7 +125,7 @@ impl DiscoveredGlyphs {
 /// move points without changing how many elements a glyph draws.
 fn fits_max_length(
     path: &Path,
-    ttc_index: u32,
+    face_index: u32,
     glyph_id: GlyphId,
     glyph: &OutlineGlyph<'_>,
     max_length: usize,
@@ -136,7 +136,7 @@ fn fits_max_length(
     )
     .map_err(|err| {
         Error::Parse(format!(
-            "failed to draw glyph id {} of '{}' (ttc_index {ttc_index}): {err}",
+            "failed to draw glyph id {} of '{}' (face_index {face_index}): {err}",
             glyph_id.to_u32(),
             path.display()
         ))
@@ -155,14 +155,14 @@ fn read_faces<T>(
     let entries = parsed
         .fonts()
         .enumerate()
-        .map(|(ttc_index, font_result)| {
+        .map(|(face_index, font_result)| {
             let font = font_result.map_err(|err| {
                 Error::Parse(format!(
-                    "failed to parse '{}' (ttc_index {ttc_index}): {err}",
+                    "failed to parse '{}' (face_index {face_index}): {err}",
                     path.display()
                 ))
             })?;
-            build(ttc_index as u32, &font)
+            build(face_index as u32, &font)
         })
         .collect::<Result<Vec<_>, Error>>()?;
     if entries.is_empty() {

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -41,10 +41,10 @@ impl CodepointIndex {
         let mut codepoints = Vec::with_capacity(sample_count);
         let mut glyph_ids = Vec::with_capacity(sample_count);
         offsets.push(0);
-        for (path, ttc_index, face_codepoints, face_glyph_ids) in faces {
+        for (path, face_index, face_codepoints, face_glyph_ids) in faces {
             debug_assert!(face_codepoints.is_sorted());
             debug_assert_eq!(face_codepoints.len(), face_glyph_ids.len());
-            fonts.push((path, ttc_index));
+            fonts.push((path, face_index));
             codepoints.extend(face_codepoints);
             glyph_ids.extend(face_glyph_ids);
             offsets.push(i64::try_from(codepoints.len()).expect("Vec length fits in i64"));
@@ -91,9 +91,9 @@ impl GlyphIndex {
         let mut offsets = Vec::with_capacity(faces.len() + 1);
         let mut glyph_ids = Vec::with_capacity(faces.iter().map(|face| face.2.len()).sum());
         offsets.push(0);
-        for (path, ttc_index, face_glyph_ids) in faces {
+        for (path, face_index, face_glyph_ids) in faces {
             debug_assert!(face_glyph_ids.is_sorted());
-            fonts.push((path, ttc_index));
+            fonts.push((path, face_index));
             glyph_ids.extend(face_glyph_ids);
             offsets.push(i64::try_from(glyph_ids.len()).expect("Vec length fits in i64"));
         }

--- a/src/font/data.rs
+++ b/src/font/data.rs
@@ -25,11 +25,11 @@ pub(crate) fn map_font(path: &Path) -> Result<Mmap, Error> {
 pub(crate) fn parse_font_ref<'a>(
     data: &'a [u8],
     path: &Path,
-    ttc_index: u32,
+    face_index: u32,
 ) -> Result<skrifa::FontRef<'a>, Error> {
-    skrifa::FontRef::from_index(data, ttc_index).map_err(|err| {
+    skrifa::FontRef::from_index(data, face_index).map_err(|err| {
         Error::Parse(format!(
-            "failed to parse '{}' (ttc_index {ttc_index}): {err}",
+            "failed to parse '{}' (face_index {face_index}): {err}",
             path.display()
         ))
     })

--- a/src/font/location.rs
+++ b/src/font/location.rs
@@ -36,7 +36,7 @@ pub(crate) fn default_location(font: &skrifa::FontRef<'_>) -> Location {
 pub(crate) fn canonicalize_location(
     font: &skrifa::FontRef<'_>,
     path: &Path,
-    ttc_index: u32,
+    face_index: u32,
     location: Option<&BTreeMap<String, f32>>,
 ) -> Result<Location, Error> {
     let Some(location) = location else {
@@ -46,7 +46,7 @@ pub(crate) fn canonicalize_location(
     for (tag, value) in location {
         let Some(axis) = axes.iter().find(|axis| axis.tag == *tag) else {
             return Err(Error::Parse(format!(
-                "font '{}' (ttc_index {ttc_index}) has no variation axis '{tag}'",
+                "font '{}' (face_index {face_index}) has no variation axis '{tag}'",
                 path.display(),
             )));
         };

--- a/src/py/transform/load.rs
+++ b/src/py/transform/load.rs
@@ -11,11 +11,11 @@ use crate::transform::load::load_glyph_outline;
 pub(crate) fn variation_axes(
     py: Python<'_>,
     path: PathBuf,
-    ttc_index: u32,
+    face_index: u32,
 ) -> PyResult<Vec<(String, f32, f32, f32)>> {
     py.detach(|| {
         let data = map_font(&path)?;
-        let font = parse_font_ref(&data[..], &path, ttc_index)?;
+        let font = parse_font_ref(&data[..], &path, face_index)?;
         Ok(axis_info(&font)
             .into_iter()
             .map(|axis| (axis.tag, axis.min, axis.default, axis.max))
@@ -29,13 +29,13 @@ type GlyphTargets = (f32, f32, f32, f32, f32);
 pub(crate) fn glyph_targets(
     py: Python<'_>,
     path: PathBuf,
-    ttc_index: u32,
+    face_index: u32,
     location: BTreeMap<String, f32>,
 ) -> PyResult<GlyphTargets> {
     py.detach(|| {
         let data = map_font(&path)?;
-        let font = parse_font_ref(&data[..], &path, ttc_index)?;
-        let location = canonicalize_location(&font, &path, ttc_index, Some(&location))?;
+        let font = parse_font_ref(&data[..], &path, face_index)?;
+        let location = canonicalize_location(&font, &path, face_index, Some(&location))?;
         let values = registered_axis_values(&font, &location);
         Ok((
             values.weight,
@@ -51,11 +51,11 @@ pub(crate) fn glyph_targets(
 pub(crate) fn load_glyph<'py>(
     py: Python<'py>,
     path: PathBuf,
-    ttc_index: u32,
+    face_index: u32,
     glyph_id: u32,
     location: Option<BTreeMap<String, f32>>,
 ) -> PyResult<super::OutlineArrays<'py>> {
     let outline =
-        py.detach(|| load_glyph_outline(&path, ttc_index, glyph_id, location.as_ref()))?;
+        py.detach(|| load_glyph_outline(&path, face_index, glyph_id, location.as_ref()))?;
     Ok(super::encode(py, &outline))
 }

--- a/src/transform/load.rs
+++ b/src/transform/load.rs
@@ -15,34 +15,34 @@ use crate::{
 
 pub(crate) fn load_glyph_outline(
     path: &Path,
-    ttc_index: u32,
+    face_index: u32,
     glyph_id: u32,
     location: Option<&BTreeMap<String, f32>>,
 ) -> Result<BezPath, Error> {
     let data = map_font(path)?;
-    let font = parse_font_ref(&data[..], path, ttc_index)?;
+    let font = parse_font_ref(&data[..], path, face_index)?;
     let units_per_em = font
         .head()
         .map_err(|err| {
             Error::Parse(format!(
-                "font '{}' (ttc_index {ttc_index}) 'head' table error: {err}",
+                "font '{}' (face_index {face_index}) 'head' table error: {err}",
                 path.display()
             ))
         })?
         .units_per_em();
     if units_per_em == 0 {
         return Err(Error::Parse(format!(
-            "font '{}' (ttc_index {ttc_index}) has zero units per em",
+            "font '{}' (face_index {face_index}) has zero units per em",
             path.display()
         )));
     }
-    let user_location = canonicalize_location(&font, path, ttc_index, location)?;
+    let user_location = canonicalize_location(&font, path, face_index, location)?;
     let glyph = font
         .outline_glyphs()
         .get(GlyphId::new(glyph_id))
         .ok_or_else(|| {
             Error::OutOfRange(format!(
-                "glyph id {glyph_id} missing from '{}' (ttc_index {ttc_index})",
+                "glyph id {glyph_id} missing from '{}' (face_index {face_index})",
                 path.display()
             ))
         })?;

--- a/tests/_glyphs.py
+++ b/tests/_glyphs.py
@@ -10,15 +10,15 @@ from __future__ import annotations
 from fontTools.ttLib import TTFont
 
 
-def glyph_id(path: str, char: str, ttc_index: int = 0) -> int:
+def glyph_id(path: str, char: str, face_index: int = 0) -> int:
     """Return the glyph id one face maps ``char`` to."""
-    font = TTFont(path, fontNumber=ttc_index)
+    font = TTFont(path, fontNumber=face_index)
     cmap = font.getBestCmap()
     assert cmap is not None
     return font.getGlyphID(cmap[ord(char)])
 
 
-def glyph_id_by_name(path: str, name: str, ttc_index: int = 0) -> int:
+def glyph_id_by_name(path: str, name: str, face_index: int = 0) -> int:
     """Return the id of one named glyph, mapped or not."""
-    font = TTFont(path, fontNumber=ttc_index)
+    font = TTFont(path, fontNumber=face_index)
     return font.getGlyphID(name)

--- a/tests/test_codepoint_dataset.py
+++ b/tests/test_codepoint_dataset.py
@@ -114,8 +114,8 @@ def test_dataset_resolves_glyph_ids_per_face() -> None:
     resolved = [dataset[idx].ref.glyph_id for idx in range(len(dataset))]
 
     assert resolved == [
-        glyph_id(f"tests/fonts/{path}", "A", ttc_index)
-        for ttc_index in range(len(dataset.font_classes))
+        glyph_id(f"tests/fonts/{path}", "A", face_index)
+        for face_index in range(len(dataset.font_classes))
     ]
 
 

--- a/tests/test_font_fixtures.py
+++ b/tests/test_font_fixtures.py
@@ -66,7 +66,7 @@ def test_collection_fixtures_expose_every_face(
     dataset = CodepointDataset(FONT_ROOT, patterns=path, codepoints=[codepoint])
 
     assert len(dataset) == face_count
-    assert [font.ttc_index for font in dataset.font_classes] == list(range(face_count))
+    assert [font.face_index for font in dataset.font_classes] == list(range(face_count))
     for sample in dataset:
         glyph = LoadGlyph()(sample)
         assert glyph.data.types.numel() > 0

--- a/tests/test_glyph_id_dataset.py
+++ b/tests/test_glyph_id_dataset.py
@@ -64,7 +64,7 @@ def test_dataset_reaches_glyphs_no_codepoint_maps_to() -> None:
 def test_dataset_indexes_each_face_of_a_collection() -> None:
     dataset = GlyphIdDataset("tests/fonts", patterns=COLLECTION_FONT)
 
-    assert [ref.ttc_index for ref in dataset.font_classes] == list(
+    assert [ref.face_index for ref in dataset.font_classes] == list(
         range(len(dataset.font_classes))
     )
     assert {PurePath(ref.path).name for ref in dataset.font_classes} == {

--- a/torchfont/_font.py
+++ b/torchfont/_font.py
@@ -16,11 +16,11 @@ class FontRef:
     """Persistent file-local reference to one font."""
 
     path: str
-    ttc_index: int
+    face_index: int
 
-    def __init__(self, path: str | PathLike[str], ttc_index: int) -> None:
+    def __init__(self, path: str | PathLike[str], face_index: int) -> None:
         object.__setattr__(self, "path", os.fspath(Path(path)))
-        object.__setattr__(self, "ttc_index", ttc_index)
+        object.__setattr__(self, "face_index", face_index)
 
 
 __all__ = ["FontRef"]

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -77,17 +77,17 @@ def index_glyphs(
 ]: ...
 def load_glyph(
     path: str,
-    ttc_index: int,
+    face_index: int,
     glyph_id: int,
     location: dict[str, float] | None = ...,
 ) -> tuple[np.ndarray, np.ndarray]: ...
 def variation_axes(
     path: str,
-    ttc_index: int,
+    face_index: int,
 ) -> list[tuple[str, float, float, float]]: ...
 def glyph_targets(
     path: str,
-    ttc_index: int,
+    face_index: int,
     location: dict[str, float],
 ) -> tuple[
     float,

--- a/torchfont/datasets/_codepoint.py
+++ b/torchfont/datasets/_codepoint.py
@@ -103,7 +103,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
         self._character_index.flags.writeable = False
         self._glyph_ids.flags.writeable = False
         self._font_refs = tuple(
-            FontRef(path, ttc_index) for path, ttc_index in font_refs
+            FontRef(path, face_index) for path, face_index in font_refs
         )
         self._offsets = tuple(offsets)
 

--- a/torchfont/datasets/_glyph_id.py
+++ b/torchfont/datasets/_glyph_id.py
@@ -86,7 +86,7 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
         )
         self._glyph_ids.flags.writeable = False
         self._font_refs = tuple(
-            FontRef(path, ttc_index) for path, ttc_index in font_refs
+            FontRef(path, face_index) for path, face_index in font_refs
         )
         self._offsets = tuple(offsets)
 

--- a/torchfont/transforms/_glyph.py
+++ b/torchfont/transforms/_glyph.py
@@ -45,7 +45,7 @@ class LoadGlyph(nn.Module):
         outline = _functional.load_glyph(ref, location)
         if isinstance(inpt, GlyphRef):
             return outline
-        metrics = _torchfont.glyph_targets(ref.font.path, ref.font.ttc_index, location)
+        metrics = _torchfont.glyph_targets(ref.font.path, ref.font.face_index, location)
         if isinstance(inpt, GlyphIdSample):
             return GlyphIdData(
                 data=outline,
@@ -71,7 +71,7 @@ class LoadGlyph(nn.Module):
 def _random_location(ref: GlyphRef) -> dict[str, float]:
     location: dict[str, float] = {}
     for tag, minimum, _default, maximum in _torchfont.variation_axes(
-        ref.font.path, ref.font.ttc_index
+        ref.font.path, ref.font.face_index
     ):
         location[str(tag)] = torch.empty(()).uniform_(minimum, maximum).item()
     return location
@@ -81,7 +81,7 @@ def _default_location(ref: GlyphRef) -> dict[str, float]:
     return {
         str(tag): float(default)
         for tag, _minimum, default, _maximum in _torchfont.variation_axes(
-            ref.font.path, ref.font.ttc_index
+            ref.font.path, ref.font.face_index
         )
     }
 

--- a/torchfont/transforms/functional/_glyph.py
+++ b/torchfont/transforms/functional/_glyph.py
@@ -27,7 +27,7 @@ def load_glyph(
     )
     raw_types, raw_coords = _torchfont.load_glyph(
         ref.font.path,
-        ref.font.ttc_index,
+        ref.font.face_index,
         ref.glyph_id,
         normalized_location,
     )


### PR DESCRIPTION
`FontRef.ttc_index` is the index of a face within its file. The value is decided
by the file contents, not by its extension: a collection renamed to `.ttf` still
yields one entry per face, a single font renamed to `.ttc` yields one entry at
index 0, and `.otc` uses the same numbering. Naming it after the TTC container
made an ordinary `.ttf` look like a special case, and the guide needed a caveat
sentence to say that a single-face font is also zero.

```python
FontRef(path='.../Metropolis.ttc', face_index=3)
```

## Why `face_index`

| Library | Name | Single-font file |
|---|---|---|
| FreeType | `face_index` | 0 |
| HarfBuzz | `index` | 0 |
| Pillow | `index` ("Which font face to load") | 0 |
| fontations | `index` | 0, non-zero is `InvalidCollectionIndex` |
| fontTools | `fontNumber` | -1 sentinel for unspecified |

The ecosystem is split between `index` and `face_index`, and both are 0-based
with a single-font file counting as one face. A bare `index` collides here:
`font_idx` is already the dataset-local class index, so `ref.font.index` and
`data.font_idx` would read as the same thing while meaning different numbers.
`face_index` also matches the sibling `GlyphRef.glyph_id` and the face
vocabulary the datasets and docs already use.

The field stays a plain `int` rather than becoming optional. A face has one
representation, so `FontRef` keeps a stable identity as a dict key and in
`font_classes`, and a caller never has to open a file to learn whether to pass
`None` or `0`.

## Testing

- `mise run check`, `mise run test` (406 passed), `npm run docs:build`