### PR TITLE
Harden build and packaging configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,10 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       - run: uv run --locked --only-group lint ruff format --check
       - run: uv run --locked --only-group lint ruff check
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo check --all-targets --all-features
+      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
+      - run: cargo check --locked --all-targets --all-features
 
   test:
     name: Test
@@ -84,7 +84,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: "true"
-      - run: cargo test --all-targets --all-features
+      - run: cargo test --locked --all-targets --all-features
       - if: matrix.environment == 'latest'
         run: uv run --locked ty check
       - if: matrix.environment != 'minimum'
@@ -119,7 +119,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --locked --release --out dist
           before-script-linux: . .github/scripts/install-linux-deps.sh ${{ matrix.platform.target }}
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
@@ -127,7 +127,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t
+          args: --locked --release --out dist -i python3.14t
           before-script-linux: . .github/scripts/install-linux-deps.sh ${{ matrix.platform.target }}
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
@@ -150,7 +150,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x64
-          args: --release --out dist
+          args: --locked --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@v7
         with:
@@ -160,7 +160,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x64
-          args: --release --out dist -i python3.14t
+          args: --locked --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -180,7 +180,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: aarch64
-          args: --release --out dist
+          args: --locked --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@v7
         with:
@@ -189,7 +189,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: aarch64
-          args: --release --out dist -i python3.14t
+          args: --locked --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run docs:build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,8 @@ dependencies = [
 [[package]]
 name = "google-fonts-glyphsets"
 version = "1.1.3"
-source = "git+https://github.com/googlefonts/glyphsets#1dbbd54ea7bf3a3e94422c746be4da2741379d0b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f217171a0d017ab0bcbd8177bc229e21b77310391210e99d10a477bd7f67998"
 dependencies = [
  "glob",
  "google-fonts-languages",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tiny-skia = { version = "0.12.0", default-features = false, features = [
     "simd",
     "std",
 ] }
-google-fonts-glyphsets = { git = "https://github.com/googlefonts/glyphsets" }
+google-fonts-glyphsets = "1.1.3"
 
 [dependencies.pyo3]
 version = "0.29.0"

--- a/mise.toml
+++ b/mise.toml
@@ -53,23 +53,25 @@ run = "cargo fmt --all -- --check"
 [tasks.rust-lint]
 description = "Lint Rust targets with Clippy"
 sources = [
+  ".python-version",
   "Cargo.toml",
   "Cargo.lock",
   "mise.lock",
   "src/**/*.rs",
 ]
-run = "cargo clippy --all-targets --all-features -- -D warnings"
+run = "uv run --locked --no-sync cargo clippy --locked --all-targets --all-features -- -D warnings"
 
 [tasks.rust-test]
 description = "Run the Rust test suite"
 sources = [
+  ".python-version",
   "Cargo.toml",
   "Cargo.lock",
   "mise.lock",
   "src/**/*.rs",
   "tests/fonts/**",
 ]
-run = "cargo test --all-targets --all-features"
+run = "uv run --locked --no-sync cargo test --locked --all-targets --all-features"
 
 [tasks.rust-check]
 description = "Run all Rust checks"
@@ -107,7 +109,7 @@ sources = [
   "torchfont/**/*.py",
 ]
 depends = ["uv-sync"]
-run = "uv run --no-sync ty check"
+run = "uv run --locked --no-sync ty check"
 
 [tasks.python-check]
 description = "Run all Python checks"
@@ -132,12 +134,12 @@ outputs = [
   'torchfont/_torchfont*.{% if os() == "windows" %}pyd{% else %}so{% endif %}',
 ]
 depends = ["check"]
-run = "uv run --no-sync maturin develop --release"
+run = "uv run --locked --no-sync maturin develop --locked --release"
 
 [tasks.test]
 description = "Run the Python test suite"
 depends = ["build"]
-run = "uv run --no-sync pytest tests"
+run = "uv run --locked --no-sync pytest tests"
 
 [tasks.data-sync]
 description = "Initialize the repository data submodules"
@@ -156,7 +158,7 @@ run = [
 [tasks.test-google-fonts]
 description = "Run tests against the Google Fonts checkout"
 depends = ["build", "data-sync"]
-run = "uv run --no-sync pytest tests/google_fonts --google-fonts -s"
+run = "uv run --locked --no-sync pytest tests/google_fonts --google-fonts -s"
 
 [tasks.docs-build]
 description = "Build the documentation site"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "torchfont",
       "devDependencies": {
-        "@types/node": "^26.2.0",
+        "@types/node": "^24.13.3",
         "vitepress": "^1.6.4"
       }
     },
@@ -1364,13 +1364,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/unist": {
@@ -2382,9 +2382,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "esbuild": "^0.28.1"
   },
   "devDependencies": {
-    "@types/node": "^26.2.0",
+    "@types/node": "^24.13.3",
     "vitepress": "^1.6.4"
   },
   "allowScripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -35,6 +37,8 @@ dynamic = ["version"]
 dependencies = ["numpy>=1.21.3", "torch>=2.5.0"]
 
 [project.urls]
+Documentation = "https://torchfont.readthedocs.io/"
+Issues = "https://github.com/torchfont/torchfont/issues"
 Repository = "https://github.com/torchfont/torchfont"
 Releases = "https://github.com/torchfont/torchfont/releases"
 
@@ -89,10 +93,8 @@ ignore = ["COM812", "CPY001", "D203", "D213", "EXE002"]
 "tests/**/*.py" = ["D", "PLR2004", "S101"]
 
 [tool.maturin]
+exclude = ["data/**"]
 module-name = "torchfont._torchfont"
-
-[tool.setuptools.package-data]
-"torchfont" = ["py.typed"]
 
 [tool.ty.rules]
 invalid-method-override = "ignore"


### PR DESCRIPTION
## Summary

- exclude the Google Fonts data submodule from source distributions
- make Rust and Python tasks use locked dependencies and reliable PyO3 Python discovery
- use the crates.io release of google-fonts-glyphsets
- align Node tooling and types with Node 24 LTS
- correct package metadata and Dependabot policy

## Validation

- `mise run sync`
- `mise run format`
- `mise run check`
- `mise run build`
- `mise run test`
- `mise run docs-build`
- Google Fonts smoke test: 3 tests passed on 3 families / 256 samples each
- sdist excludes `data/` and is reduced from 1.6 GB to 3.1 MB