### PR TITLE
Use tensors for batched outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,26 @@ pip install torchfont
 ## Quickstart
 
 ```python
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 
-from torchfont import CodepointData, Outline, pad_outlines
+from torchfont import CodepointData, ElementType, Outline
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(samples: list[CodepointData[Outline]]) -> Outline:
-    return pad_outlines([sample.data for sample in samples])
+def collate_fn(samples: list[CodepointData[Outline]]):
+    outlines = [sample.data for sample in samples]
+    return {
+        "types": pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        "coords": pad_sequence(
+            [outline.coords for outline in outlines], batch_first=True
+        ),
+    }
 
 
 dataset = CodepointDataset(
@@ -71,14 +82,11 @@ loader = DataLoader(
     shuffle=True,
     collate_fn=collate_fn,
 )
-outlines = next(iter(loader))
+batch = next(iter(loader))
 
-print(outlines.types.shape)  # (8, L)
-print(outlines.coords.shape)  # (8, L, 6)
+print(batch["types"].shape)  # (8, L)
+print(batch["coords"].shape)  # (8, L, 6)
 ```
-
-Use `pad_outlines` to pad variable-length outlines. A model that also needs
-targets can add them to the batch in its local `collate_fn`.
 
 ## What TorchFont Focuses On
 

--- a/docs/en/guide/advanced/multiprocessing.md
+++ b/docs/en/guide/advanced/multiprocessing.md
@@ -13,10 +13,11 @@ Use `tqdm` to iterate over all batches and measure throughput:
 
 ```python
 import torch
+from torch.nn.utils.rnn import pad_sequence
 from tqdm import tqdm
 from torch.utils.data import DataLoader
 
-from torchfont import CodepointData, Outline, pad_outlines
+from torchfont import CodepointData, ElementType, Outline
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import LoadGlyph
 
@@ -24,8 +25,16 @@ MAX_ELEMENTS = 512
 
 
 def collate_fn(samples: list[CodepointData[Outline]]):
+    outlines = [sample.data[:MAX_ELEMENTS] for sample in samples]
     return {
-        "outline": pad_outlines([sample.data[:MAX_ELEMENTS] for sample in samples]),
+        "types": pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        "coords": pad_sequence(
+            [outline.coords for outline in outlines], batch_first=True
+        ),
         "font_idx": torch.tensor(
             [sample.font_idx for sample in samples], dtype=torch.long
         ),

--- a/docs/en/guide/basic/dataloader.md
+++ b/docs/en/guide/basic/dataloader.md
@@ -51,23 +51,33 @@ torch.Size([37, 6])
 ## Create a DataLoader
 
 Glyph outline sequences are variable-length, so define a local `collate_fn` for
-the exact input contract of your model. Use `pad_outlines` for the payload and
-tensorize only the targets the model needs:
+the exact input contract of your model. Use PyTorch's `pad_sequence` for the
+outline tensors and tensorize only the targets the model needs:
 
 ```python
 import math
 
 import torch
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import CodepointDataset
-from torchfont import CodepointData, Outline, pad_outlines
+from torchfont import CodepointData, ElementType, Outline
 from torchfont.transforms import LoadGlyph
 
 
 def collate_fn(samples: list[CodepointData[Outline]]):
+    outlines = [sample.data for sample in samples]
     return {
-        "outline": pad_outlines([sample.data for sample in samples]),
+        "types": pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        "coords": pad_sequence(
+            [outline.coords for outline in outlines], batch_first=True
+        ),
+        "lengths": torch.tensor([len(outline) for outline in outlines]),
         "font_idx": torch.tensor(
             [sample.font_idx for sample in samples], dtype=torch.long
         ),
@@ -100,8 +110,8 @@ loader = DataLoader(
 )
 batch = next(iter(loader))
 
-print(batch["outline"].shape)
-print(batch["outline"].coords.shape)
+print(batch["types"].shape)
+print(batch["coords"].shape)
 print(batch["weight"].shape)
 ```
 
@@ -118,45 +128,29 @@ torch.Size([64])
 
 ## Work with a padded batch
 
-Padded elements use `ElementType.PAD`. Rather than recovering them by comparing
-against that value, read `padding_mask`, which is exactly what attention modules
-expect as `key_padding_mask`:
+Padded elements use `ElementType.PAD`. Build the boolean mask expected by
+attention modules directly from the padded element types:
 
 ```python
-mask = batch["outline"].padding_mask  # (64, 369), True where padding
+mask = batch["types"] == ElementType.PAD  # (64, 369), True where padding
 ```
 
-`unpad_outlines()` explicitly splits a padded batch back into the single
-outlines that went in. By contrast, `Outline.unbind()` preserves padding just
-like an ordinary tensor operation:
+Keep the original lengths when the padded tensors must be restored with
+PyTorch's `unpad_sequence`:
 
 ```python
-from torchfont import unpad_outlines
+from torch.nn.utils.rnn import unpad_sequence
 
-singles = unpad_outlines(batch["outline"])
-
-print(len(singles), singles[0].shape)
+types = unpad_sequence(batch["types"], batch["lengths"], batch_first=True)
+coords = unpad_sequence(batch["coords"], batch["lengths"], batch_first=True)
 ```
 
-`torchfont.nn` modules take an `Outline`, batched or not, so a padded batch goes
-straight into a model:
+`torchfont.nn` modules take the padded tensors directly:
 
 ```python
 from torchfont.nn import OutlineEmbedding
 
-tokens = OutlineEmbedding(embedding_dim=256)(batch["outline"])
+tokens = OutlineEmbedding(embedding_dim=256)(batch["types"], batch["coords"])
 
 print(tokens.shape)  # (64, 369, 256)
-```
-
-## Batch outlines without a DataLoader
-
-`pad_outlines` applies the same padding step directly:
-
-```python
-from torchfont import pad_outlines
-
-batched = pad_outlines([dataset[0].data, dataset[1].data])
-
-print(batched.shape)
 ```

--- a/docs/en/guide/basic/glyph-data-format.md
+++ b/docs/en/guide/basic/glyph-data-format.md
@@ -95,9 +95,7 @@ The seven types are `MOVE_TO`, `LINE_TO`, `QUAD_TO`, `CURVE_TO`, `CLOSE`,
 `END`, and `PAD`.
 
 - `ElementType.END` marks the end of the sequence
-- `ElementType.PAD` marks rows introduced by padding a batch. Loading a font
-  never produces it, and a single glyph never contains it. Read
-  `outline.padding_mask` rather than comparing against the value.
+- `ElementType.PAD` marks padded batch rows
 
 ## Coordinates
 

--- a/docs/en/reference/core-types.md
+++ b/docs/en/reference/core-types.md
@@ -14,8 +14,6 @@ from torchfont import (
     GlyphIdSample,
     GlyphRef,
     Outline,
-    pad_outlines,
-    unpad_outlines,
 )
 ```
 
@@ -24,61 +22,30 @@ references, and dataset samples can be used with multiprocessing data loaders.
 
 ### `Outline`
 
-`Outline` pairs two coupled tensors. `types` has shape `(*batch, N)`, `coords`
-has shape `(*batch, N, 6)`, and their rows correspond one-to-one. `types` uses
+`Outline` pairs two coupled tensors. `types` has shape `(N,)`,
+`coords` has shape `(N, 6)`, and their rows correspond one-to-one. `types` uses
 `torch.long`, `coords` uses any floating point dtype, and both tensors are on the
 same device. Coordinates that are inactive for an element type,
 including all coordinates for `CLOSE`, `END`, and `PAD`, have no semantic value.
-
-A single glyph has an empty batch shape. [`pad_outlines`](#pad-outlines) stacks
-single glyphs into a batch. Most transforms operate on single glyphs and reject a
-batched `Outline` with an explicit error.
 
 These properties describe an outline without taking it apart:
 
 | Property | Meaning |
 | --- | --- |
-| `shape` | shape of `types`, that is `(*batch, N)` |
-| `batch_shape` | leading batch dimensions, empty for a single glyph |
-| `num_elements` | path elements per glyph, including padding |
-| `is_batched` | whether any batch dimension is present |
+| `shape` | shape of `types`, that is `(N,)` |
+| `num_elements` | number of path elements |
 | `dtype` | floating point dtype of `coords` |
 | `device` | device shared by both tensors |
-| `padding_mask` | boolean mask, `True` where an element is `PAD` |
 
 `to()` and `pin_memory()` apply to both tensors at once. A dtype passed to
 `to()` applies to `coords` only and must be floating point. Operate on `types`
-or `coords` directly for other tensor operations. Indexing addresses the
-logical `(*batch, N)` dimensions while
-always leaving the coordinate axis intact. An index may not remove the final
-element dimension. `len()` reports the first logical dimension. `unbind()`
-splits the first batch dimension without changing its contents.
+or `coords` directly for other tensor operations. Indexing preserves the
+element dimension and coordinate axis. `len()` reports the number of elements.
 
 `Outline` objects compare by identity. Compare `types` and `coords` explicitly
 with `torch.equal()` when content equality is required. In-place changes to the
 input tensors are visible through the outline. Assigning a different tensor to
 either attribute raises an error.
-
-### `pad_outlines`
-
-```python
-pad_outlines(outlines: Sequence[Outline]) -> Outline
-```
-
-Stacks single outlines into one batch padded with `ElementType.PAD` and zero
-coordinates. Every input must be a single glyph sharing one device and one
-`coords` dtype. Recover the padding with `padding_mask`, and undo it with
-[`unpad_outlines`](#unpad-outlines).
-
-### `unpad_outlines`
-
-```python
-unpad_outlines(outline: Outline) -> tuple[Outline, ...]
-```
-
-Splits an `Outline` with exactly one batch dimension and removes trailing
-`ElementType.PAD` rows from each result. This is the explicit inverse of
-`pad_outlines`; use `Outline.unbind()` when padding must be preserved.
 
 ### `CodepointData`
 
@@ -97,8 +64,8 @@ continuous target is `None`.
 when content equality is required.
 
 Define a local `DataLoader.collate_fn` for the model's input contract and use
-[`pad_outlines`](#pad-outlines) when its payloads are variable-length outlines.
-See [DataLoader](../guide/basic/dataloader.md).
+PyTorch's `pad_sequence` when its payloads are variable-length outlines. See
+[DataLoader](../guide/basic/dataloader.md).
 
 ### `GlyphIdData`
 

--- a/docs/en/reference/nn.md
+++ b/docs/en/reference/nn.md
@@ -1,9 +1,7 @@
 # Neural Network Building Blocks
 
-TorchFont provides small font-specific building blocks in `torchfont.nn`.
-They take an [`Outline`](./core-types.md#outline), batched or not, and return
-ordinary tensors, so they compose with standard PyTorch modules, devices, dtypes,
-autograd, and serialization.
+TorchFont provides small font-specific building blocks in `torchfont.nn` that
+accept element-type and coordinate tensors.
 
 ## `OutlineEmbedding`
 
@@ -13,19 +11,17 @@ token features:
 ```python
 import torch
 
-from torchfont import ElementType, Outline
+from torchfont import ElementType
 from torchfont.nn import OutlineEmbedding
 
 embedding = OutlineEmbedding(embedding_dim=256)
-outline = Outline(
-    torch.tensor(
-        [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
-    ),
-    torch.zeros((1, 4, 6)),  # (batch, sequence, 6)
+types = torch.tensor(
+    [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
 )
+coords = torch.zeros((1, 4, 6))  # (batch, sequence, 6)
 
-tokens = embedding(outline)  # (1, 4, 256)
-padding_mask = outline.padding_mask  # (1, 4)
+tokens = embedding(types, coords)  # (1, 4, 256)
+padding_mask = types == ElementType.PAD  # (1, 4)
 ```
 
 The module adds a learned element-type embedding to a bias-free linear
@@ -49,7 +45,7 @@ meaning for the target element type:
 ```python
 from torchfont.nn import functional as F
 
-loss = F.coordinate_loss(predicted_coords, target_outline)
+loss = F.coordinate_loss(predicted_coords, target_types, target_coords)
 ```
 
 - `MOVE_TO` and `LINE_TO`: endpoint only
@@ -57,7 +53,8 @@ loss = F.coordinate_loss(predicted_coords, target_outline)
 - `CURVE_TO`: both control points and endpoint
 - `CLOSE`, `END`, and `PAD`: no coordinates
 
-Predictions have shape `(..., N, 6)`, matching the target's coordinates.
+Predictions and target coordinates have shape `(..., N, 6)`, while target
+types have shape `(..., N)`.
 Supported reductions are `"none"`, `"mean"`, and `"sum"`.
 The mean is taken over active coordinate scalars rather than padded storage.
 If there are no active coordinates, the mean is a differentiable zero.
@@ -72,7 +69,7 @@ into one training objective:
 from torchfont.nn import OutlineLoss
 
 criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
-loss = criterion(type_logits, predicted_coords, target_outline)
+loss = criterion(type_logits, predicted_coords, target_types, target_coords)
 ```
 
 `type_logits` has shape `(..., N, TYPE_DIM)`. Cross entropy is averaged over

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -139,20 +139,6 @@ shape = bitmap.shape
 The functional API does not sample randomness. Random selection and parameter
 sampling belong to the `Random*` transform classes.
 
-### Single glyphs only
-
-Every operation in this section accepts a single glyph. Passing a batched
-`Outline` raises:
-
-```python
-F.affine(batch, angle=5.0)
-# ValueError: affine operates on a single outline, got batch shape (64,);
-#             iterate with unpad_outlines() first
-```
-
-Transforms run per sample, before collation. Batch a pipeline's output with
-[`pad_outlines`](./core-types.md#pad-outlines) or a `DataLoader`.
-
 ### Differentiability
 
 Gradient support varies by operation:

--- a/docs/ja/guide/advanced/multiprocessing.md
+++ b/docs/ja/guide/advanced/multiprocessing.md
@@ -12,10 +12,11 @@
 
 ```python
 import torch
+from torch.nn.utils.rnn import pad_sequence
 from tqdm import tqdm
 from torch.utils.data import DataLoader
 
-from torchfont import CodepointData, Outline, pad_outlines
+from torchfont import CodepointData, ElementType, Outline
 from torchfont.datasets import CodepointDataset
 from torchfont.transforms import LoadGlyph
 
@@ -23,8 +24,16 @@ MAX_ELEMENTS = 512
 
 
 def collate_fn(samples: list[CodepointData[Outline]]):
+    outlines = [sample.data[:MAX_ELEMENTS] for sample in samples]
     return {
-        "outline": pad_outlines([sample.data[:MAX_ELEMENTS] for sample in samples]),
+        "types": pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        "coords": pad_sequence(
+            [outline.coords for outline in outlines], batch_first=True
+        ),
         "font_idx": torch.tensor(
             [sample.font_idx for sample in samples], dtype=torch.long
         ),

--- a/docs/ja/guide/basic/dataloader.md
+++ b/docs/ja/guide/basic/dataloader.md
@@ -51,23 +51,33 @@ torch.Size([37, 6])
 ## DataLoader を作成する
 
 グリフのアウトライン系列は可変長なので、モデルの入力契約に合うローカルな
-`collate_fn` を定義します。データ本体には `pad_outlines` を使い、モデルが必要とする
-ターゲットだけをテンソルに変換します。
+`collate_fn` を定義します。アウトライン Tensor には PyTorch の `pad_sequence` を使い、
+モデルが必要とするターゲットだけをテンソルに変換します。
 
 ```python
 import math
 
 import torch
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import CodepointDataset
-from torchfont import CodepointData, Outline, pad_outlines
+from torchfont import CodepointData, ElementType, Outline
 from torchfont.transforms import LoadGlyph
 
 
 def collate_fn(samples: list[CodepointData[Outline]]):
+    outlines = [sample.data for sample in samples]
     return {
-        "outline": pad_outlines([sample.data for sample in samples]),
+        "types": pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        "coords": pad_sequence(
+            [outline.coords for outline in outlines], batch_first=True
+        ),
+        "lengths": torch.tensor([len(outline) for outline in outlines]),
         "font_idx": torch.tensor(
             [sample.font_idx for sample in samples], dtype=torch.long
         ),
@@ -100,8 +110,8 @@ loader = DataLoader(
 )
 batch = next(iter(loader))
 
-print(batch["outline"].shape)
-print(batch["outline"].coords.shape)
+print(batch["types"].shape)
+print(batch["coords"].shape)
 print(batch["weight"].shape)
 ```
 
@@ -117,43 +127,29 @@ torch.Size([64])
 
 ## パディング済みバッチを扱う
 
-パディングされた要素は `ElementType.PAD` です。その値と直接比較する代わりに
-`padding_mask` を使用します。これは Attention モジュールへ `key_padding_mask` として
-そのまま渡せます。
+パディングされた要素は `ElementType.PAD` です。Attention モジュールが
+`key_padding_mask` として期待する Boolean Mask を Element Type から直接作ります。
 
 ```python
-mask = batch["outline"].padding_mask  # (64, 369)、パディング位置が True
+mask = batch["types"] == ElementType.PAD  # (64, 369)、パディング位置が True
 ```
 
-`unpad_outlines()` はパディング済みバッチを分割し、入力時の個々の `Outline` に戻します。
-一方、`Outline.unbind()` は通常のテンソル操作と同じくパディングを保持します。
+Padding 済み Tensor を復元する必要がある場合は元の Length を保持し、PyTorch の
+`unpad_sequence` を使います。
 
 ```python
-from torchfont import unpad_outlines
+from torch.nn.utils.rnn import unpad_sequence
 
-singles = unpad_outlines(batch["outline"])
-
-print(len(singles), singles[0].shape)
+types = unpad_sequence(batch["types"], batch["lengths"], batch_first=True)
+coords = unpad_sequence(batch["coords"], batch["lengths"], batch_first=True)
 ```
 
-`torchfont.nn` のモジュールはバッチ化の有無を問わず `Outline` を受け取るので、パディング済みバッチをそのままモデルに渡せます。
+`torchfont.nn` のモジュールには Padding 済み Tensor を直接渡します。
 
 ```python
 from torchfont.nn import OutlineEmbedding
 
-tokens = OutlineEmbedding(embedding_dim=256)(batch["outline"])
+tokens = OutlineEmbedding(embedding_dim=256)(batch["types"], batch["coords"])
 
 print(tokens.shape)  # (64, 369, 256)
-```
-
-## DataLoader を使わずにバッチ化する
-
-`pad_outlines` は同じパディング処理を直接呼び出せます。
-
-```python
-from torchfont import pad_outlines
-
-batched = pad_outlines([dataset[0].data, dataset[1].data])
-
-print(batched.shape)
 ```

--- a/docs/ja/guide/basic/glyph-data-format.md
+++ b/docs/ja/guide/basic/glyph-data-format.md
@@ -98,9 +98,7 @@ MOVE_TO
 7 つです。
 
 - `ElementType.END` はシーケンス終端を表します
-- `ElementType.PAD` はバッチのパディングで導入された行を標識します。フォントの
-  読み込みでは生成されず、単一グリフには含まれません。値と比較するのではなく
-  `outline.padding_mask` を読んでください
+- `ElementType.PAD` はバッチのパディング行を表します
 
 ## 座標
 

--- a/docs/ja/reference/core-types.md
+++ b/docs/ja/reference/core-types.md
@@ -14,8 +14,6 @@ from torchfont import (
     GlyphIdSample,
     GlyphRef,
     Outline,
-    pad_outlines,
-    unpad_outlines,
 )
 ```
 
@@ -24,58 +22,28 @@ Dataset Sample はマルチプロセスの DataLoader でも使用できます�
 
 ### `Outline`
 
-`Outline` は結合した二つのテンソルを保持します。`types` は形状 `(*batch, N)` の
-`torch.long`、`coords` は形状 `(*batch, N, 6)` の任意の浮動小数点型で、各行が
+`Outline` は結合した二つのテンソルを保持します。`types` は形状 `(N,)` の
+`torch.long`、`coords` は形状 `(N, 6)` の任意の浮動小数点型で、各行が
 一対一に対応し、同じデバイス上に置かれます。各要素型で使われない座標、および
 `CLOSE`、`END`、`PAD` の全座標には意味がありません。
-
-単一グリフの Batch 形状は空です。[`pad_outlines`](#pad-outlines) は単一グリフを
-バッチにまとめます。ほとんどの Transform は単一グリフだけを扱い、バッチ化された
-`Outline` は明示的なエラーで拒否します。
 
 次のプロパティで、中身を取り出さずに Outline を調べられます。
 
 | プロパティ | 意味 |
 | --- | --- |
-| `shape` | `types` の形状、つまり `(*batch, N)` |
-| `batch_shape` | 先頭の Batch 次元。単一グリフでは空 |
-| `num_elements` | パディングを含む 1 グリフあたりの要素数 |
-| `is_batched` | Batch 次元を持つかどうか |
+| `shape` | `types` の形状、つまり `(N,)` |
+| `num_elements` | Path 要素数 |
 | `dtype` | `coords` の浮動小数点型 |
 | `device` | 両テンソルが共有するデバイス |
-| `padding_mask` | 要素が `PAD` の位置で `True` になる Boolean Mask |
 
 `to()` と `pin_memory()` は両方のテンソルに同時に適用されます。`to()` に渡す dtype は
 `coords` にのみ適用され、浮動小数点型でなければなりません。それ以外の Tensor 操作は
-`types` または `coords` に直接適用します。Index は座標軸を常に保ったまま論理的な `(*batch, N)` 次元を
-対象にし、最後の要素次元を取り除く Index は使えません。`len()` は最初の論理次元の
-長さを返します。`unbind()` は内容を変更せず、最初の
-Batch 次元だけを分割します。
+`types` または `coords` に直接適用します。Index は要素次元と座標軸を保持します。
+`len()` は要素数を返します。
 
 `Outline` 同士は同一性で比較されます。内容の等値性が必要な場合は `types` と
 `coords` を `torch.equal()` で明示的に比較します。入力テンソルをその場で変更すると、
 その変更は Outline にも反映されます。どちらの属性への代入もエラーになります。
-
-### `pad_outlines`
-
-```python
-pad_outlines(outlines: Sequence[Outline]) -> Outline
-```
-
-単一 Outline を `ElementType.PAD` とゼロ座標でパディングして一つのバッチに
-まとめます。入力はすべて単一グリフで、デバイスと `coords` の dtype が共通で
-なければなりません。パディング位置は `padding_mask` で取得でき、
-[`unpad_outlines`](#unpad-outlines) で元に戻せます。
-
-### `unpad_outlines`
-
-```python
-unpad_outlines(outline: Outline) -> tuple[Outline, ...]
-```
-
-Batch 次元がちょうど一つの `Outline` を分割し、各結果の末尾にある
-`ElementType.PAD` 行を除去します。これは `pad_outlines` の明示的な逆操作です。
-Padding を保持する場合は `Outline.unbind()` を使います。
 
 ### `CodepointData`
 
@@ -93,7 +61,7 @@ Index は Python の整数、連続 Target は Float です。取得できない
 明示的な Tensor 比較を使ってください。
 
 モデルの入力契約に合わせてローカルな `DataLoader.collate_fn` を定義し、Payload が可変長 Outline の
-場合は [`pad_outlines`](#pad-outlines) を使います。
+場合は PyTorch の `pad_sequence` を使います。
 [DataLoader](../guide/basic/dataloader.md) を参照してください。
 
 ### `GlyphIdData`

--- a/docs/ja/reference/nn.md
+++ b/docs/ja/reference/nn.md
@@ -1,9 +1,7 @@
 # ニューラルネットワーク構成要素
 
-TorchFont は、フォント固有の小さな構成要素を `torchfont.nn` で提供します。
-バッチ化の有無を問わず [`Outline`](./core-types.md#outline) を受け取り、通常の
-テンソルを返すため、標準の PyTorch Module、Device、Dtype、Autograd、
-Serialization と組み合わせられます。
+TorchFont は、要素型と座標の Tensor を受け取るフォント固有の構成要素を
+`torchfont.nn` で提供します。
 
 ## `OutlineEmbedding`
 
@@ -12,19 +10,17 @@ Serialization と組み合わせられます。
 ```python
 import torch
 
-from torchfont import ElementType, Outline
+from torchfont import ElementType
 from torchfont.nn import OutlineEmbedding
 
 embedding = OutlineEmbedding(embedding_dim=256)
-outline = Outline(
-    torch.tensor(
-        [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
-    ),
-    torch.zeros((1, 4, 6)),  # (batch, sequence, 6)
+types = torch.tensor(
+    [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
 )
+coords = torch.zeros((1, 4, 6))  # (batch, sequence, 6)
 
-tokens = embedding(outline)  # (1, 4, 256)
-padding_mask = outline.padding_mask  # (1, 4)
+tokens = embedding(types, coords)  # (1, 4, 256)
+padding_mask = types == ElementType.PAD  # (1, 4)
 ```
 
 学習可能な要素型 Embedding と、Bias なしの線形層による6次元連続座標の射影を加算します。
@@ -45,7 +41,7 @@ embedding = OutlineEmbedding(256, device="cuda", dtype=torch.float16)
 ```python
 from torchfont.nn import functional as F
 
-loss = F.coordinate_loss(predicted_coords, target_outline)
+loss = F.coordinate_loss(predicted_coords, target_types, target_coords)
 ```
 
 - `MOVE_TO` と `LINE_TO`: End Point のみ
@@ -53,7 +49,7 @@ loss = F.coordinate_loss(predicted_coords, target_outline)
 - `CURVE_TO`: 二つの Control Point と End Point
 - `CLOSE`、`END`、`PAD`: 座標なし
 
-Prediction の Shape は `(..., N, 6)` で、Target の座標と一致します。Reduction は `"none"`、`"mean"`、`"sum"` に対応します。Mean は Padding を含む格納領域ではなく、
+Prediction と Target 座標の Shape は `(..., N, 6)`、Target 型は `(..., N)` です。Reduction は `"none"`、`"mean"`、`"sum"` に対応します。Mean は Padding を含む格納領域ではなく、
 有効な座標 Scalar に対して計算されます。有効な座標がない場合、Mean は微分可能なゼロになります。
 無効な座標 Slot にある非有限値は無視されます。
 
@@ -65,7 +61,7 @@ Prediction の Shape は `(..., N, 6)` で、Target の座標と一致します�
 from torchfont.nn import OutlineLoss
 
 criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
-loss = criterion(type_logits, predicted_coords, target_outline)
+loss = criterion(type_logits, predicted_coords, target_types, target_coords)
 ```
 
 `type_logits` の Shape は `(..., N, TYPE_DIM)` です。Cross Entropy は Padding 以外の要素で平均し、

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -136,20 +136,6 @@ shape = bitmap.shape
 Functional API は乱数を生成しません。ランダムな選択とパラメーターのサンプリングは
 `Random*` Transform クラスの責務です。
 
-### 単一グリフのみを扱う
-
-この節の各処理は単一グリフを対象とします。バッチ化された `Outline` を渡すと
-エラーになります。
-
-```python
-F.affine(batch, angle=5.0)
-# ValueError: affine operates on a single outline, got batch shape (64,);
-#             iterate with unpad_outlines() first
-```
-
-Transform は Collate の前にサンプルごとに実行されます。パイプラインの出力は
-[`pad_outlines`](./core-types.md#pad-outlines) または `DataLoader` でバッチ化してください。
-
 ### 微分可能性
 
 勾配への対応は処理ごとに異なります。

--- a/examples/transform.py
+++ b/examples/transform.py
@@ -1,13 +1,23 @@
+from torch import Tensor
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from torchfont import CodepointData, Outline, pad_outlines
+from torchfont import CodepointData, ElementType, Outline
 from torchfont import transforms as T
 from torchfont.datasets import CodepointDataset
 
 
-def collate_fn(batch: list[CodepointData[Outline]]) -> Outline:
-    return pad_outlines([data.data for data in batch])
+def collate_fn(batch: list[CodepointData[Outline]]) -> tuple[Tensor, Tensor]:
+    outlines = [data.data for data in batch]
+    return (
+        pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        pad_sequence([outline.coords for outline in outlines], batch_first=True),
+    )
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ ignore = ["COM812", "CPY001", "D203", "D213", "EXE002"]
 "examples/**/*.py" = ["D", "N812", "T201"]
 # Operator signatures are fixed by the schema each kernel is registered with.
 "torchfont/_ops.py" = ["FBT001", "PLR0913", "PLR0917"]
+"torchfont/nn/functional.py" = ["PLR0913"]
 "torchfont/transforms/functional/_geometry.py" = ["PLR0913"]
 "tests/**/*.py" = ["D", "PLR2004", "S101"]
 

--- a/tests/nn/test_embedding.py
+++ b/tests/nn/test_embedding.py
@@ -10,12 +10,10 @@ def test_outline_embedding_combines_types_and_coordinates() -> None:
     with torch.no_grad():
         embedding.type_embedding.weight.fill_(1.0)
         embedding.coord_projection.weight.fill_(2.0)
-    outline = Outline(
-        torch.tensor([[ElementType.MOVE_TO, ElementType.LINE_TO]]),
-        torch.ones((1, 2, 6)),
-    )
+    types = torch.tensor([[ElementType.MOVE_TO, ElementType.LINE_TO]])
+    coords = torch.ones((1, 2, 6))
 
-    output = embedding(outline)
+    output = embedding(types, coords)
 
     assert output.shape == (1, 2, 3)
     assert torch.equal(output, torch.full((1, 2, 3), 5.0))
@@ -36,7 +34,7 @@ def test_outline_embedding_ignores_inactive_coordinates() -> None:
         ),
     )
 
-    output = embedding(outline)
+    output = embedding(outline.types, outline.coords)
 
     assert torch.equal(output[:, 0], torch.tensor([3.0, 10.0]))
 
@@ -56,7 +54,7 @@ def test_outline_embedding_ignores_nonfinite_inactive_coordinates() -> None:
         ),
     )
 
-    output = embedding(outline)
+    output = embedding(outline.types, outline.coords)
 
     assert torch.equal(output, torch.tensor([[3.0], [0.0]]))
 
@@ -67,7 +65,7 @@ def test_outline_embedding_zeroes_padding_tokens() -> None:
         torch.tensor([ElementType.MOVE_TO, ElementType.PAD]), torch.ones((2, 6))
     )
 
-    output = embedding(outline)
+    output = embedding(outline.types, outline.coords)
 
     assert torch.count_nonzero(output[0]) > 0
     assert torch.count_nonzero(output[1]) == 0
@@ -79,7 +77,7 @@ def test_outline_embedding_supports_factory_dtype() -> None:
         torch.tensor([ElementType.MOVE_TO]), torch.ones((1, 6), dtype=torch.float64)
     )
 
-    output = embedding(outline)
+    output = embedding(outline.types, outline.coords)
 
     assert output.dtype == torch.float64
     assert embedding.type_embedding.weight.dtype == torch.float64
@@ -94,6 +92,11 @@ def test_outline_embedding_registers_parameters() -> None:
         "coord_projection.weight",
     }
     assert repr(embedding).startswith("OutlineEmbedding(\n  embedding_dim=4")
+
+
+def test_outline_embedding_rejects_misaligned_tensors() -> None:
+    with pytest.raises(ValueError, match="coords must have shape"):
+        OutlineEmbedding(4)(torch.zeros(2, dtype=torch.long), torch.zeros(1, 6))
 
 
 def test_outline_embedding_initializes_both_branches_from_one_bound() -> None:

--- a/tests/nn/test_functional.py
+++ b/tests/nn/test_functional.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torchfont import ElementType, Outline
+from torchfont import ElementType
 from torchfont.nn.functional import coordinate_loss
 
 
@@ -24,7 +24,7 @@ def test_coordinate_loss_masks_inactive_coordinates() -> None:
     prediction = torch.zeros((len(types), 6))
     target = torch.ones_like(prediction)
 
-    loss = coordinate_loss(prediction, Outline(types, target), reduction="none")
+    loss = coordinate_loss(prediction, types, target, reduction="none")
 
     expected = torch.tensor(
         [
@@ -51,7 +51,7 @@ def test_coordinate_loss_ignores_nonfinite_inactive_coordinates() -> None:
         ]
     )
 
-    loss = coordinate_loss(prediction, Outline(types, target), reduction="none")
+    loss = coordinate_loss(prediction, types, target, reduction="none")
 
     assert torch.equal(
         loss,
@@ -63,7 +63,7 @@ def test_coordinate_loss_mean_is_zero_without_active_coordinates() -> None:
     types = torch.tensor([ElementType.CLOSE, ElementType.END, ElementType.PAD])
     prediction = torch.zeros((3, 6), requires_grad=True)
 
-    loss = coordinate_loss(prediction, Outline(types, torch.ones_like(prediction)))
+    loss = coordinate_loss(prediction, types, torch.ones_like(prediction))
     loss.backward()
 
     assert loss.item() == 0.0
@@ -76,11 +76,8 @@ def test_coordinate_loss_reductions_count_only_active_coordinates() -> None:
     prediction = torch.zeros((len(types), 6))
     target = torch.ones_like(prediction)
 
-    assert coordinate_loss(prediction, Outline(types, target)).item() == 1.0
-    assert (
-        coordinate_loss(prediction, Outline(types, target), reduction="sum").item()
-        == 14.0
-    )
+    assert coordinate_loss(prediction, types, target).item() == 1.0
+    assert coordinate_loss(prediction, types, target, reduction="sum").item() == 14.0
 
 
 def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> None:
@@ -88,7 +85,7 @@ def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> Non
     prediction = torch.zeros((2, 6), requires_grad=True)
     target = torch.ones_like(prediction)
 
-    coordinate_loss(prediction, Outline(types, target), reduction="sum").backward()
+    coordinate_loss(prediction, types, target, reduction="sum").backward()
 
     grad = prediction.grad
     assert grad is not None
@@ -97,16 +94,27 @@ def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> Non
 
 
 def test_coordinate_loss_rejects_a_prediction_that_does_not_match_the_target() -> None:
-    target = Outline(torch.zeros(3, dtype=torch.long), torch.zeros((3, 6)))
+    target_types = torch.zeros(3, dtype=torch.long)
+    target_coords = torch.zeros((3, 6))
 
     with pytest.raises(ValueError, match="same shape as the target coordinates"):
-        coordinate_loss(torch.zeros((2, 6)), target)
+        coordinate_loss(torch.zeros((2, 6)), target_types, target_coords)
+
+
+def test_coordinate_loss_rejects_misaligned_target_tensors() -> None:
+    with pytest.raises(ValueError, match="coords must have shape"):
+        coordinate_loss(
+            torch.zeros((2, 6)),
+            torch.zeros(1, dtype=torch.long),
+            torch.zeros((2, 6)),
+        )
 
 
 def test_coordinate_loss_rejects_invalid_reduction() -> None:
     with pytest.raises(ValueError, match="not a valid value"):
         coordinate_loss(
             torch.zeros((1, 6)),
-            Outline(torch.tensor([ElementType.MOVE_TO]), torch.zeros((1, 6))),
+            torch.tensor([ElementType.MOVE_TO]),
+            torch.zeros((1, 6)),
             reduction="invalid",  # ty: ignore[invalid-argument-type]
         )

--- a/tests/nn/test_loss.py
+++ b/tests/nn/test_loss.py
@@ -2,38 +2,41 @@ import pytest
 import torch
 from torch.nn import functional as torch_functional
 
-from torchfont import TYPE_DIM, ElementType, Outline
+from torchfont import TYPE_DIM, ElementType
 from torchfont.nn import OutlineLoss
 from torchfont.nn import functional as font_functional
 
 
-def _inputs() -> tuple[torch.Tensor, torch.Tensor, Outline]:
+def _inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     type_logits = torch.zeros((3, TYPE_DIM), requires_grad=True)
     coordinate_prediction = torch.zeros((3, 6), requires_grad=True)
-    target = Outline(
-        torch.tensor([ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.PAD]),
-        torch.ones_like(coordinate_prediction),
+    target_types = torch.tensor(
+        [ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.PAD]
     )
-    return type_logits, coordinate_prediction, target
+    target_coords = torch.ones_like(coordinate_prediction)
+    return type_logits, coordinate_prediction, target_types, target_coords
 
 
 def test_outline_loss_combines_independently_averaged_losses() -> None:
-    type_logits, prediction, target = _inputs()
+    type_logits, prediction, target_types, target_coords = _inputs()
 
     loss = font_functional.outline_loss(
         type_logits,
         prediction,
-        target,
+        target_types,
+        target_coords,
         type_weight=2.0,
         coordinate_weight=3.0,
     )
 
     expected_type_loss = torch_functional.cross_entropy(
         type_logits,
-        target.types,
+        target_types,
         ignore_index=ElementType.PAD,
     )
-    expected_coord_loss = font_functional.coordinate_loss(prediction, target)
+    expected_coord_loss = font_functional.coordinate_loss(
+        prediction, target_types, target_coords
+    )
     assert torch.allclose(loss, 2 * expected_type_loss + 3 * expected_coord_loss)
 
 
@@ -53,9 +56,9 @@ def test_outline_loss_module_delegates_to_functional_loss() -> None:
 
 
 def test_outline_loss_backpropagates_through_both_predictions() -> None:
-    type_logits, prediction, target = _inputs()
+    type_logits, prediction, target_types, target_coords = _inputs()
 
-    OutlineLoss()(type_logits, prediction, target).backward()
+    OutlineLoss()(type_logits, prediction, target_types, target_coords).backward()
 
     assert type_logits.grad is not None
     assert prediction.grad is not None
@@ -66,11 +69,10 @@ def test_outline_loss_backpropagates_through_both_predictions() -> None:
 def test_outline_loss_is_zero_for_all_padding() -> None:
     type_logits = torch.zeros((2, TYPE_DIM), requires_grad=True)
     prediction = torch.zeros((2, 6), requires_grad=True)
-    target = Outline(
-        torch.tensor([ElementType.PAD, ElementType.PAD]), torch.zeros_like(prediction)
-    )
+    target_types = torch.tensor([ElementType.PAD, ElementType.PAD])
+    target_coords = torch.zeros_like(prediction)
 
-    loss = OutlineLoss()(type_logits, prediction, target)
+    loss = OutlineLoss()(type_logits, prediction, target_types, target_coords)
     loss.backward()
 
     assert loss.item() == 0.0
@@ -91,7 +93,9 @@ def test_outline_loss_rejects_misaligned_type_logits(
     logits_shape: tuple[int, ...],
     match: str,
 ) -> None:
-    _, prediction, target = _inputs()
+    _, prediction, target_types, target_coords = _inputs()
 
     with pytest.raises(ValueError, match=match):
-        font_functional.outline_loss(torch.zeros(logits_shape), prediction, target)
+        font_functional.outline_loss(
+            torch.zeros(logits_shape), prediction, target_types, target_coords
+        )

--- a/tests/nn/test_outline_inputs.py
+++ b/tests/nn/test_outline_inputs.py
@@ -1,11 +1,12 @@
-"""``torchfont.nn`` operating on single and batched :class:`torchfont.Outline`."""
+"""``torchfont.nn`` operating on single and batched outline tensors."""
 
 from __future__ import annotations
 
 import pytest
 import torch
+from torch.nn.utils.rnn import pad_sequence
 
-from torchfont import COORD_DIM, TYPE_DIM, ElementType, Outline, pad_outlines
+from torchfont import COORD_DIM, TYPE_DIM, ElementType, Outline
 from torchfont.nn import OutlineEmbedding, OutlineLoss
 from torchfont.nn import functional as F  # noqa: N812
 
@@ -19,45 +20,65 @@ def _outline(length: int = 4) -> Outline:
 
 
 @pytest.fixture
-def batch() -> Outline:
-    return pad_outlines([_outline(), _outline(3)])
-
-
-def test_embedding_accepts_a_single_outline() -> None:
-    assert OutlineEmbedding(8)(_outline()).shape == (4, 8)
-
-
-def test_embedding_accepts_a_batched_outline(batch: Outline) -> None:
-    assert OutlineEmbedding(8)(batch).shape == (2, 4, 8)
-
-
-def test_loss_accepts_a_batched_outline(batch: Outline) -> None:
-    logits = torch.zeros(*batch.shape, TYPE_DIM)
-    prediction = torch.zeros(*batch.shape, COORD_DIM)
-
-    assert OutlineLoss()(logits, prediction, batch).ndim == 0
-
-
-def test_coordinate_loss_accepts_a_batched_outline(batch: Outline) -> None:
-    prediction = torch.zeros(*batch.shape, COORD_DIM)
-
-    assert F.coordinate_loss(prediction, batch).ndim == 0
-
-
-def test_loss_ignores_padding_introduced_by_pad_outlines() -> None:
-    single = _outline(3)
-    batch = pad_outlines([single, single])
-    padded_loss = OutlineLoss()(
-        torch.zeros(*batch.shape, TYPE_DIM),
-        torch.zeros(*batch.shape, COORD_DIM),
-        batch,
+def batch() -> tuple[torch.Tensor, torch.Tensor]:
+    outlines = [_outline(), _outline(3)]
+    return (
+        pad_sequence(
+            [outline.types for outline in outlines],
+            batch_first=True,
+            padding_value=ElementType.PAD,
+        ),
+        pad_sequence([outline.coords for outline in outlines], batch_first=True),
     )
 
-    unpadded = pad_outlines([single])
+
+def test_embedding_accepts_single_outline_tensors() -> None:
+    outline = _outline()
+    assert OutlineEmbedding(8)(outline.types, outline.coords).shape == (4, 8)
+
+
+def test_embedding_accepts_batched_outline_tensors(
+    batch: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    assert OutlineEmbedding(8)(*batch).shape == (2, 4, 8)
+
+
+def test_loss_accepts_batched_outline_tensors(
+    batch: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = batch
+    logits = torch.zeros(*types.shape, TYPE_DIM)
+
+    assert OutlineLoss()(logits, torch.zeros_like(coords), types, coords).ndim == 0
+
+
+def test_coordinate_loss_accepts_batched_outline_tensors(
+    batch: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = batch
+
+    assert F.coordinate_loss(torch.zeros_like(coords), types, coords).ndim == 0
+
+
+def test_loss_ignores_padding_introduced_by_pad_sequence() -> None:
+    single = _outline(3)
+    types = pad_sequence(
+        [single.types, single.types],
+        batch_first=True,
+        padding_value=ElementType.PAD,
+    )
+    coords = pad_sequence([single.coords, single.coords], batch_first=True)
+    padded_loss = OutlineLoss()(
+        torch.zeros(*types.shape, TYPE_DIM),
+        torch.zeros_like(coords),
+        types,
+        coords,
+    )
     unpadded_loss = OutlineLoss()(
-        torch.zeros(*unpadded.shape, TYPE_DIM),
-        torch.zeros(*unpadded.shape, COORD_DIM),
-        unpadded,
+        torch.zeros(1, *single.shape, TYPE_DIM),
+        torch.zeros(1, *single.coords.shape),
+        single.types.unsqueeze(0),
+        single.coords.unsqueeze(0),
     )
 
     assert torch.allclose(padded_loss, unpadded_loss)

--- a/tests/test_core_types.py
+++ b/tests/test_core_types.py
@@ -42,7 +42,7 @@ def test_glyph_ref_identifies_face_and_glyph() -> None:
         (
             torch.zeros((1, 1), dtype=torch.long),
             torch.zeros((1, 6)),
-            "exactly one more dimension",
+            "types must be 1-D",
         ),
         (
             torch.zeros(1, dtype=torch.long),
@@ -57,7 +57,7 @@ def test_glyph_ref_identifies_face_and_glyph() -> None:
         (
             torch.zeros((2, 3), dtype=torch.long),
             torch.zeros((2, 4, 6)),
-            "types shape must match coords",
+            "types must be 1-D",
         ),
     ],
 )
@@ -98,14 +98,9 @@ def test_outline_accepts_any_floating_coords_dtype(dtype: torch.dtype) -> None:
     assert outline.dtype is dtype
 
 
-def test_outline_accepts_batch_dimensions() -> None:
-    outline = Outline(torch.zeros((4, 9), dtype=torch.long), torch.zeros((4, 9, 6)))
-
-    assert outline.is_batched
-    assert outline.shape == (4, 9)
-    assert outline.batch_shape == (4,)
-    assert outline.num_elements == 9
-    assert len(outline) == 4
+def test_outline_rejects_batch_dimensions() -> None:
+    with pytest.raises(ValueError, match="types must be 1-D"):
+        Outline(torch.zeros((4, 9), dtype=torch.long), torch.zeros((4, 9, 6)))
 
 
 def test_outline_keeps_identity_equality() -> None:

--- a/tests/test_outline_container.py
+++ b/tests/test_outline_container.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from torch.utils import _pytree as pytree
 
-from torchfont import ElementType, Outline, pad_outlines, unpad_outlines
+from torchfont import ElementType, Outline
 from torchfont.transforms import Affine
 
 
@@ -30,9 +30,7 @@ def triangle() -> Outline:
 
 def test_outline_exposes_tensor_metadata(triangle: Outline) -> None:
     assert triangle.shape == (5,)
-    assert triangle.batch_shape == ()
     assert triangle.num_elements == 5
-    assert not triangle.is_batched
     assert triangle.dtype is torch.float32
     assert triangle.device == torch.device("cpu")
 
@@ -89,15 +87,6 @@ def test_registering_outline_as_a_pytree_node_would_break_transforms(
     assert pytree.tree_flatten(triangle)[0] == [triangle]
 
 
-def test_padding_mask_marks_padding(triangle: Outline) -> None:
-    batch = pad_outlines([triangle, triangle[:3]])
-
-    assert batch.padding_mask.tolist() == [
-        [False] * 5,
-        [False, False, False, True, True],
-    ]
-
-
 def test_indexing_keeps_the_coordinate_axis(triangle: Outline) -> None:
     head = triangle[:2]
 
@@ -105,96 +94,9 @@ def test_indexing_keeps_the_coordinate_axis(triangle: Outline) -> None:
     assert head.coords.shape == (2, 6)
 
 
-def test_indexing_with_ellipsis_keeps_the_coordinate_axis() -> None:
-    outline = Outline(
-        torch.ones(2, 3, 4, dtype=torch.long),
-        torch.zeros(2, 3, 4, 6),
-    )
-
-    result = outline[..., :2]
-
-    assert result.shape == (2, 3, 2)
-    assert result.coords.shape == (2, 3, 2, 6)
-
-
 def test_indexing_rejects_removing_the_element_dimension(triangle: Outline) -> None:
     with pytest.raises(IndexError, match="preserve the outline element dimension"):
         triangle[0]
-
-
-def test_pad_outlines_stacks_to_the_longest(triangle: Outline) -> None:
-    batch = pad_outlines([triangle, triangle[:2], triangle[:4]])
-
-    assert batch.shape == (3, 5)
-    assert batch.coords.shape == (3, 5, 6)
-    assert batch.is_batched
-    assert len(batch) == 3
-
-
-def test_pad_outlines_then_unpad_round_trips(triangle: Outline) -> None:
-    parts = [triangle, triangle[:2], triangle[:4]]
-    restored = unpad_outlines(pad_outlines(parts))
-
-    assert len(restored) == len(parts)
-    for actual, expected in zip(restored, parts, strict=True):
-        assert torch.equal(actual.types, expected.types)
-        assert torch.equal(actual.coords, expected.coords)
-
-
-def test_unbind_preserves_padding(triangle: Outline) -> None:
-    batch = pad_outlines([triangle, triangle[:2]])
-
-    assert [part.shape for part in batch.unbind()] == [(5,), (5,)]
-
-
-def test_unbind_multidimensional_batch_keeps_padding() -> None:
-    outline = Outline(
-        torch.ones(2, 3, 4, dtype=torch.long),
-        torch.zeros(2, 3, 4, 6),
-    )
-
-    parts = outline.unbind()
-
-    assert [part.shape for part in parts] == [(3, 4), (3, 4)]
-
-
-def test_unbind_rejects_a_single_outline(triangle: Outline) -> None:
-    with pytest.raises(ValueError, match="unbind requires a batched outline"):
-        triangle.unbind()
-
-
-def test_unpad_outlines_rejects_a_single_outline(triangle: Outline) -> None:
-    with pytest.raises(ValueError, match="requires exactly one batch dimension"):
-        unpad_outlines(triangle)
-
-
-def test_unpad_outlines_rejects_a_multidimensional_batch() -> None:
-    outline = Outline(
-        torch.ones(2, 3, 4, dtype=torch.long),
-        torch.zeros(2, 3, 4, 6),
-    )
-
-    with pytest.raises(ValueError, match="requires exactly one batch dimension"):
-        unpad_outlines(outline)
-
-
-def test_pad_outlines_rejects_an_empty_sequence() -> None:
-    with pytest.raises(ValueError, match="must not be empty"):
-        pad_outlines([])
-
-
-def test_pad_outlines_rejects_a_batched_input(triangle: Outline) -> None:
-    """The copy into the padded tensor raises on a shape mismatch."""
-    batch = pad_outlines([triangle, triangle])
-
-    with pytest.raises(RuntimeError):
-        pad_outlines([batch])
-
-
-def test_pad_outlines_rejects_mixed_dtypes(triangle: Outline) -> None:
-    """Unlike a shape or device mismatch, a dtype mismatch would cast silently."""
-    with pytest.raises(ValueError, match="share one coords dtype"):
-        pad_outlines([triangle, triangle.to(torch.float64)])
 
 
 def test_outline_aliases_its_tensors(triangle: Outline) -> None:

--- a/tests/transforms/test_autograd.py
+++ b/tests/transforms/test_autograd.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 import torch
 
-from torchfont import ElementType, Outline, pad_outlines
+from torchfont import ElementType, Outline
 from torchfont.transforms import functional as F  # noqa: N812
 
 if TYPE_CHECKING:
@@ -98,25 +98,3 @@ def test_rust_kernels_name_themselves_when_grad_is_required(
 
     with pytest.raises(RuntimeError, match=f"{name}.*is not differentiable"):
         call(outline)
-
-
-@pytest.mark.parametrize(
-    ("name", "call"),
-    [
-        ("affine", lambda outline: F.affine(outline, angle=5.0)),
-        ("cubic_to_quad", F.cubic_to_quad),
-        ("remove_overlaps", F.remove_overlaps),
-        ("render_bitmap", F.render_bitmap),
-        (
-            "coord_jitter",
-            lambda outline: F.coord_jitter(outline, torch.zeros(5, 3, 2)),
-        ),
-    ],
-)
-def test_kernels_reject_a_batched_outline(
-    name: str, call: Callable[[Outline], object]
-) -> None:
-    batch = pad_outlines([_curved(), _curved()])
-
-    with pytest.raises(ValueError, match=f"{name} operates on a single outline"):
-        call(batch)

--- a/torchfont/__init__.py
+++ b/torchfont/__init__.py
@@ -43,8 +43,6 @@ from torchfont._outline import (
     TYPE_DIM,
     ElementType,
     Outline,
-    pad_outlines,
-    unpad_outlines,
 )
 
 from . import datasets, glyphsets, nn, transforms
@@ -63,7 +61,5 @@ __all__ = [
     "datasets",
     "glyphsets",
     "nn",
-    "pad_outlines",
     "transforms",
-    "unpad_outlines",
 ]

--- a/torchfont/_outline.py
+++ b/torchfont/_outline.py
@@ -10,7 +10,6 @@ import torch
 from torch import Tensor
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from types import EllipsisType
 
     _Index = (
@@ -43,14 +42,10 @@ COORD_DIM: int = 6
 class Outline:
     """Glyph outlines encoded by two coupled tensors.
 
-    ``types`` has shape ``(*batch, N)`` and ``coords`` has shape
-    ``(*batch, N, 6)`` with rows ``[cx0, cy0, cx1, cy1, x, y]``. Rows correspond
+    ``types`` has shape ``(N,)`` and ``coords`` has shape ``(N, 6)`` with rows
+    ``[cx0, cy0, cx1, cy1, x, y]``. Rows correspond
     one-to-one. Coordinates inactive for an element type, including every
     coordinate of ``CLOSE``, ``END``, and ``PAD``, carry no semantic value.
-
-    A single glyph has an empty ``batch`` shape; :func:`pad_outlines` stacks
-    single glyphs into a batch padded with ``ElementType.PAD``. Most transforms
-    operate on single glyphs only and reject batches explicitly.
 
     An ``Outline`` holds references to its tensors rather than copies, so
     mutating ``types`` or ``coords`` in place is visible through it, as tensor
@@ -67,20 +62,14 @@ class Outline:
 
     def __post_init__(self) -> None:
         """Reject structurally invalid coupled tensors at construction."""
-        if self.types.ndim < 1:
-            msg = f"types must have at least 1 dimension, got {self.types.ndim}"
+        if self.types.ndim != 1:
+            msg = f"types must be 1-D, got {self.types.ndim}-D"
             raise ValueError(msg)
-        if self.coords.ndim != self.types.ndim + 1:
-            msg = (
-                f"coords must have exactly one more dimension than types, "
-                f"got {self.coords.ndim} and {self.types.ndim}"
-            )
-            raise ValueError(msg)
-        if self.coords.shape[-1] != COORD_DIM:
+        if self.coords.ndim != self.types.ndim + 1 or self.coords.shape[1] != COORD_DIM:
             shape = tuple(self.coords.shape)
-            msg = f"coords must have shape (*batch, N, {COORD_DIM}), got {shape}"
+            msg = f"coords must have shape (N, {COORD_DIM}), got {shape}"
             raise ValueError(msg)
-        if self.types.shape != self.coords.shape[:-1]:
+        if self.types.shape[0] != self.coords.shape[0]:
             msg = (
                 "types shape must match coords without its last dimension, "
                 f"got {tuple(self.types.shape)} and {tuple(self.coords.shape)}"
@@ -103,23 +92,13 @@ class Outline:
 
     @property
     def shape(self) -> torch.Size:
-        """Shape of ``types``, that is ``(*batch, N)``."""
+        """Shape of ``types``, that is ``(N,)``."""
         return self.types.shape
 
     @property
-    def batch_shape(self) -> torch.Size:
-        """Leading batch dimensions, empty for a single glyph."""
-        return torch.Size(self.types.shape[:-1])
-
-    @property
     def num_elements(self) -> int:
-        """Number of path elements per glyph, including padding."""
+        """Number of path elements."""
         return self.types.shape[-1]
-
-    @property
-    def is_batched(self) -> bool:
-        """Whether this outline carries at least one batch dimension."""
-        return self.types.ndim > 1
 
     @property
     def dtype(self) -> torch.dtype:
@@ -130,14 +109,6 @@ class Outline:
     def device(self) -> torch.device:
         """Device shared by ``types`` and ``coords``."""
         return self.coords.device
-
-    @property
-    def padding_mask(self) -> Tensor:
-        """Boolean mask that is ``True`` where an element is ``PAD``.
-
-        Pass this to attention modules expecting ``key_padding_mask``.
-        """
-        return self.types == ElementType.PAD.value
 
     def to(
         self,
@@ -185,22 +156,6 @@ class Outline:
             raise IndexError(msg)
         return self._wrap(types, coords)
 
-    def unbind(self) -> tuple[Outline, ...]:
-        """Split the first batch dimension without changing its contents."""
-        if not self.is_batched:
-            msg = "unbind requires a batched outline"
-            raise ValueError(msg)
-        return tuple(self[index] for index in range(self.types.shape[0]))
-
-    def _strip_padding(self) -> Outline:
-        """Drop trailing ``PAD`` elements along the last dimension."""
-        if self.is_batched:
-            msg = "padding can only be stripped from a single outline"
-            raise ValueError(msg)
-        kept = (self.types != ElementType.PAD.value).nonzero()
-        length = 0 if kept.numel() == 0 else int(kept[-1]) + 1
-        return self._wrap(self.types[:length], self.coords[:length])
-
     def __repr__(self) -> str:
         """Summarise shape, dtype, and device instead of dumping both tensors."""
         return (
@@ -209,51 +164,9 @@ class Outline:
         )
 
 
-def pad_outlines(outlines: Sequence[Outline]) -> Outline:
-    """Stack single outlines into one batch padded with ``ElementType.PAD``.
-
-    Every input must be a single glyph on a common device with a common
-    ``coords`` dtype. Shorter outlines are padded to the longest length with
-    ``PAD`` element types and zero coordinates.
-
-    Use :attr:`Outline.padding_mask` on the result to recover which elements are
-    padding, and :meth:`Outline.unbind` to undo the padding.
-    """
-    if len(outlines) == 0:
-        msg = "outlines must not be empty"
-        raise ValueError(msg)
-    first = outlines[0]
-    # Only the dtype is checked: a mismatched shape or device makes the copy
-    # below raise, while a mismatched dtype would silently cast the coordinates.
-    if any(outline.dtype != first.dtype for outline in outlines):
-        msg = "all outlines must share one coords dtype"
-        raise ValueError(msg)
-    length = max(outline.num_elements for outline in outlines)
-    types = first.types.new_full((len(outlines), length), ElementType.PAD.value)
-    coords = first.coords.new_zeros((len(outlines), length, COORD_DIM))
-    for index, outline in enumerate(outlines):
-        end = outline.num_elements
-        types[index, :end] = outline.types
-        coords[index, :end] = outline.coords
-    return Outline._wrap(types, coords)  # noqa: SLF001
-
-
-def unpad_outlines(outline: Outline) -> tuple[Outline, ...]:
-    """Split a padded one-dimensional batch and remove trailing padding."""
-    if len(outline.batch_shape) != 1:
-        msg = (
-            "unpad_outlines requires exactly one batch dimension, got "
-            f"{tuple(outline.batch_shape)}"
-        )
-        raise ValueError(msg)
-    return tuple(part._strip_padding() for part in outline.unbind())  # noqa: SLF001
-
-
 __all__ = [
     "COORD_DIM",
     "TYPE_DIM",
     "ElementType",
     "Outline",
-    "pad_outlines",
-    "unpad_outlines",
 ]

--- a/torchfont/nn/_utils.py
+++ b/torchfont/nn/_utils.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
-from torchfont._outline import ElementType
+from torchfont._outline import COORD_DIM, ElementType
+
+
+def _validate_outline_tensors(types: Tensor, coords: Tensor) -> None:
+    expected = (*types.shape, COORD_DIM)
+    if coords.shape != expected:
+        msg = f"coords must have shape {expected} for types, got {tuple(coords.shape)}"
+        raise ValueError(msg)
 
 
 def _active_coordinate_mask(types: Tensor) -> Tensor:

--- a/torchfont/nn/functional.py
+++ b/torchfont/nn/functional.py
@@ -8,36 +8,36 @@ import torch
 from torch.nn import functional as _functional
 
 from torchfont._outline import TYPE_DIM, ElementType
-from torchfont.nn._utils import _active_coordinate_mask
+from torchfont.nn._utils import _active_coordinate_mask, _validate_outline_tensors
 
 if TYPE_CHECKING:
     from torch import Tensor
-
-    from torchfont._outline import Outline
 
 _Reduction = Literal["none", "mean", "sum"]
 
 
 def coordinate_loss(
     prediction: Tensor,
-    target: Outline,
+    target_types: Tensor,
+    target_coords: Tensor,
     reduction: _Reduction = "mean",
 ) -> Tensor:
     """Compute squared error over coordinates active for each target type.
 
-    ``prediction`` has shape ``(..., N, 6)`` and ``target`` is the outline it is
-    compared against. Inactive control points and coordinates belonging to
-    ``CLOSE``, ``END``, or ``PAD`` do not contribute.
+    ``prediction`` and ``target_coords`` have shape ``(..., N, 6)`` while
+    ``target_types`` has shape ``(..., N)``. Inactive control points and
+    coordinates belonging to ``CLOSE``, ``END``, or ``PAD`` do not contribute.
     """
-    if prediction.shape != target.coords.shape:
+    if prediction.shape != target_coords.shape:
         msg = (
             "prediction must have the same shape as the target coordinates, "
-            f"got {tuple(prediction.shape)} and {tuple(target.coords.shape)}"
+            f"got {tuple(prediction.shape)} and {tuple(target_coords.shape)}"
         )
         raise ValueError(msg)
+    _validate_outline_tensors(target_types, target_coords)
 
-    mask = _active_coordinate_mask(target.types)
-    difference = torch.where(mask, prediction - target.coords, 0)
+    mask = _active_coordinate_mask(target_types)
+    difference = torch.where(mask, prediction - target_coords, 0)
     loss = difference.square()
     if reduction == "none":
         return loss
@@ -52,7 +52,8 @@ def coordinate_loss(
 def outline_loss(
     type_logits: Tensor,
     coordinate_prediction: Tensor,
-    target: Outline,
+    target_types: Tensor,
+    target_coords: Tensor,
     *,
     type_weight: float = 1.0,
     coordinate_weight: float = 100.0,
@@ -63,11 +64,11 @@ def outline_loss(
     averaged independently over coordinate scalars active for the target
     element types, then the two means are combined using the given weights.
     """
-    if type_logits.shape[:-1] != target.types.shape:
+    if type_logits.shape[:-1] != target_types.shape:
         msg = (
             "type_logits shape without its last dimension must match the target "
             "element types, "
-            f"got {tuple(type_logits.shape)} and {tuple(target.types.shape)}"
+            f"got {tuple(type_logits.shape)} and {tuple(target_types.shape)}"
         )
         raise ValueError(msg)
     if type_logits.shape[-1] != TYPE_DIM:
@@ -76,13 +77,13 @@ def outline_loss(
 
     type_loss = _functional.cross_entropy(
         type_logits.reshape(-1, TYPE_DIM),
-        target.types.reshape(-1),
+        target_types.reshape(-1),
         ignore_index=ElementType.PAD.value,
         reduction="sum",
     )
-    type_count = (target.types != ElementType.PAD.value).sum().clamp_min(1)
+    type_count = (target_types != ElementType.PAD.value).sum().clamp_min(1)
     type_loss = type_loss / type_count
-    coords_loss = coordinate_loss(coordinate_prediction, target)
+    coords_loss = coordinate_loss(coordinate_prediction, target_types, target_coords)
     return type_weight * type_loss + coordinate_weight * coords_loss
 
 

--- a/torchfont/nn/modules/embedding.py
+++ b/torchfont/nn/modules/embedding.py
@@ -7,16 +7,16 @@ import math
 import torch
 from torch import Tensor, nn
 
-from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType, Outline
-from torchfont.nn._utils import _active_coordinate_mask
+from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType
+from torchfont.nn._utils import _active_coordinate_mask, _validate_outline_tensors
 
 
 class OutlineEmbedding(nn.Module):
     """Embed element types and continuous coordinates into token features.
 
-    Accepts an :class:`~torchfont.Outline`, single or batched. Its shape is
-    ``(..., N)``, so the output has shape ``(..., N, embedding_dim)``. Padding
-    tokens produce zero vectors.
+    ``types`` has shape ``(..., N)`` and ``coords`` has shape ``(..., N, 6)``,
+    so the output has shape ``(..., N, embedding_dim)``. Padding tokens produce
+    zero vectors.
     """
 
     def __init__(
@@ -53,9 +53,9 @@ class OutlineEmbedding(nn.Module):
         with torch.no_grad():
             self.type_embedding.weight[ElementType.PAD.value].zero_()
 
-    def forward(self, outline: Outline) -> Tensor:
+    def forward(self, types: Tensor, coords: Tensor) -> Tensor:
         """Return the sum of element-type and coordinate embeddings."""
-        types, coords = outline.types, outline.coords
+        _validate_outline_tensors(types, coords)
         active_coords = torch.where(_active_coordinate_mask(types), coords, 0)
         embedded = self.type_embedding(types) + self.coord_projection(active_coords)
         return torch.where((types != ElementType.PAD.value).unsqueeze(-1), embedded, 0)

--- a/torchfont/nn/modules/loss.py
+++ b/torchfont/nn/modules/loss.py
@@ -11,8 +11,6 @@ from torchfont.nn import functional
 if TYPE_CHECKING:
     from torch import Tensor
 
-    from torchfont._outline import Outline
-
 
 class OutlineLoss(nn.Module):
     """Combine element-type and active-coordinate losses.
@@ -36,13 +34,15 @@ class OutlineLoss(nn.Module):
         self,
         type_logits: Tensor,
         coordinate_prediction: Tensor,
-        target: Outline,
+        target_types: Tensor,
+        target_coords: Tensor,
     ) -> Tensor:
         """Return the weighted mean outline loss."""
         return functional.outline_loss(
             type_logits,
             coordinate_prediction,
-            target,
+            target_types,
+            target_coords,
             type_weight=self.type_weight,
             coordinate_weight=self.coordinate_weight,
         )

--- a/torchfont/transforms/functional/_bitmap.py
+++ b/torchfont/transforms/functional/_bitmap.py
@@ -6,7 +6,7 @@ from torch import Tensor
 
 from torchfont import _ops
 from torchfont._outline import Outline
-from torchfont.transforms.functional._utils import _require_no_grad, _require_single
+from torchfont.transforms.functional._utils import _require_no_grad
 
 BitmapMode = Literal["fixed", "bbox", "bbox_square"]
 FillRule = Literal["winding", "even_odd"]
@@ -48,7 +48,6 @@ def render_bitmap(
         rejected.
 
     """
-    _require_single(inpt, "render_bitmap")
     _require_no_grad(inpt, "render_bitmap")
     return _ops.render_bitmap(inpt.types, inpt.coords, size, mode, fill_rule, antialias)
 

--- a/torchfont/transforms/functional/_geometry.py
+++ b/torchfont/transforms/functional/_geometry.py
@@ -26,7 +26,6 @@ from torchfont import _ops
 from torchfont._outline import ElementType, Outline
 from torchfont.transforms.functional._utils import (
     _require_no_grad,
-    _require_single,
     _same_types,
 )
 
@@ -231,7 +230,6 @@ def horizontal_flip(inpt: Outline, *, preserve_winding: bool = True) -> Outline:
     Differentiable only when ``preserve_winding`` is ``False``; reversing
     subpaths reorders elements in Rust and defines no gradient.
     """
-    _require_single(inpt, "horizontal_flip")
     if preserve_winding:
         _require_no_grad(inpt, "horizontal_flip(preserve_winding=True)")
     out_types, out_coords = _horizontal_flip(
@@ -246,7 +244,6 @@ def vertical_flip(inpt: Outline, *, preserve_winding: bool = True) -> Outline:
     Differentiable only when ``preserve_winding`` is ``False``; reversing
     subpaths reorders elements in Rust and defines no gradient.
     """
-    _require_single(inpt, "vertical_flip")
     if preserve_winding:
         _require_no_grad(inpt, "vertical_flip(preserve_winding=True)")
     out_types, out_coords = _vertical_flip(
@@ -268,7 +265,6 @@ def affine(
     Differentiable with respect to ``coords``. The bounding-box centre the
     transform pivots around is treated as a constant reference frame.
     """
-    _require_single(inpt, "affine")
     return _same_types(
         inpt,
         _affine(
@@ -287,7 +283,6 @@ def coord_jitter(inpt: Outline, noise: Tensor) -> Outline:
 
     Differentiable with respect to both ``coords`` and ``noise``.
     """
-    _require_single(inpt, "coord_jitter")
     types, coords = inpt.types, inpt.coords
     noise_tail_shape = (3, 2)
     if (

--- a/torchfont/transforms/functional/_utils.py
+++ b/torchfont/transforms/functional/_utils.py
@@ -12,16 +12,6 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 
-def _require_single(inpt: Outline, name: str) -> None:
-    """Reject a batched outline for a kernel defined on one glyph."""
-    if inpt.is_batched:
-        msg = (
-            f"{name} operates on a single outline, got batch shape "
-            f"{tuple(inpt.batch_shape)}; iterate with unpad_outlines() first"
-        )
-        raise ValueError(msg)
-
-
 def _require_no_grad(inpt: Outline, name: str) -> None:
     """Reject an outline that requires grad for a non-differentiable kernel.
 
@@ -48,7 +38,6 @@ def _native_outline(
     ``operation`` is a :mod:`torchfont._ops` custom operator, so the Rust call is
     one opaque node that :func:`torch.compile` can capture.
     """
-    _require_single(inpt, name)
     _require_no_grad(inpt, name)
     out_types, out_coords = operation(inpt.types, inpt.coords, *args)
     return Outline._wrap(out_types, out_coords)  # noqa: SLF001


### PR DESCRIPTION
## Summary

- keep `Outline` as the single-glyph representation
- use PyTorch `pad_sequence` and ordinary tensors for batching
- update `torchfont.nn` modules and losses to accept element-type and coordinate tensors
- remove the custom padding helpers and batch-only `Outline` API

## Validation

- `mise run check`
- `mise run test` (391 passed, 12 skipped)
- Google Fonts smoke tests with `--limit 100` (3 passed)
- `mise run docs-build`
- compiled `OutlineEmbedding` and `OutlineLoss` with `torch.compile(fullgraph=True)`