### PR TITLE
Refine API naming

### DIFF
--- a/docs/en/reference/core-types.md
+++ b/docs/en/reference/core-types.md
@@ -93,11 +93,3 @@ class ElementType(IntEnum):
 
 `PAD` is never produced by loading a font. It marks rows introduced by padding a
 batch.
-
-### `TYPE_DIM: int`
-
-Number of element types. Current value: `7`.
-
-### `COORD_DIM: int`
-
-Coordinates width. Current value: `6` (`[cx0, cy0, cx1, cy1, x, y]`).

--- a/docs/en/reference/nn.md
+++ b/docs/en/reference/nn.md
@@ -37,15 +37,15 @@ The constructor accepts PyTorch-style `device` and `dtype` keyword arguments:
 embedding = OutlineEmbedding(256, device="cuda", dtype=torch.float16)
 ```
 
-## `coordinate_loss`
+## `coordinate_mse_loss`
 
-`coordinate_loss` computes squared error only over coordinates that carry
+`coordinate_mse_loss` computes squared error only over coordinates that carry
 meaning for the target element type:
 
 ```python
 from torchfont.nn import functional as F
 
-loss = F.coordinate_loss(predicted_coords, target_types, target_coords)
+loss = F.coordinate_mse_loss(predicted_coords, target_types, target_coords)
 ```
 
 - `MOVE_TO` and `LINE_TO`: endpoint only
@@ -72,7 +72,7 @@ criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
 loss = criterion(type_logits, predicted_coords, target_types, target_coords)
 ```
 
-`type_logits` has shape `(..., N, TYPE_DIM)`. Cross entropy is averaged over
+`type_logits` has shape `(..., N, len(ElementType))`. Cross entropy is averaged over
 non-padding
 elements, while coordinate error is averaged independently over active
 coordinate scalars. The two means are then combined using `type_weight` and
@@ -81,6 +81,6 @@ lengths and padding amounts. An all-padding input produces a differentiable
 zero loss.
 
 The loss intentionally has no `reduction` argument. Use PyTorch cross entropy
-and `coordinate_loss` separately when unreduced components or a different
+and `coordinate_mse_loss` separately when unreduced components or a different
 aggregation are required. The equivalent functional API is
 `torchfont.nn.functional.outline_loss`.

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -73,8 +73,8 @@ inside an already-applied transform.
 | Containers | `Compose`, `RandomApply` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpaths | `NormalizeSubpathStartPoints`, `RandomizeSubpathStartPoints`, `RandomizeSubpathOrder` |
-| Geometry | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `RandomCoordJitter` |
+| Subpaths | `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Geometry | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
 | Output | `RenderBitmap` |
 
 `RenderBitmap` changes each `Outline` leaf into a plain `uint8` tensor. When
@@ -146,7 +146,7 @@ Gradient support varies by operation:
 | Kernel | Differentiable |
 | --- | --- |
 | `affine` | yes |
-| `coord_jitter` | yes, in both the outline and the noise |
+| `add_coordinate_noise` | yes, in both the outline and the noise |
 | `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
 | `remove_overlaps`, `remove_overlap_groups` | no |
@@ -174,7 +174,7 @@ Convert other outlines explicitly before calling them:
 outline = outline.to("cpu", torch.float32)
 ```
 
-`RandomCoordJitter` and `functional.coord_jitter` preserve the input device and
+`GaussianNoise` and `functional.add_coordinate_noise` preserve the input device and
 floating point dtype.
 
 ### `torch.compile`

--- a/docs/ja/reference/core-types.md
+++ b/docs/ja/reference/core-types.md
@@ -89,11 +89,3 @@ class ElementType(IntEnum):
 
 `PAD` はフォントの読み込みでは生成されません。バッチのパディングで導入された行を
 標識します。
-
-### `TYPE_DIM: int`
-
-要素型の数。現在値は `7`。
-
-### `COORD_DIM: int`
-
-座標の次元数。現在値は `6`（`[cx0, cy0, cx1, cy1, x, y]`）。

--- a/docs/ja/reference/nn.md
+++ b/docs/ja/reference/nn.md
@@ -34,14 +34,14 @@ Constructor は PyTorch と同様に `device` と `dtype` Keyword Argument を�
 embedding = OutlineEmbedding(256, device="cuda", dtype=torch.float16)
 ```
 
-## `coordinate_loss`
+## `coordinate_mse_loss`
 
-`coordinate_loss` は、Target の要素型に対して意味を持つ座標だけの二乗誤差を計算します。
+`coordinate_mse_loss` は、Target の要素型に対して意味を持つ座標だけの二乗誤差を計算します。
 
 ```python
 from torchfont.nn import functional as F
 
-loss = F.coordinate_loss(predicted_coords, target_types, target_coords)
+loss = F.coordinate_mse_loss(predicted_coords, target_types, target_coords)
 ```
 
 - `MOVE_TO` と `LINE_TO`: End Point のみ
@@ -64,11 +64,11 @@ criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
 loss = criterion(type_logits, predicted_coords, target_types, target_coords)
 ```
 
-`type_logits` の Shape は `(..., N, TYPE_DIM)` です。Cross Entropy は Padding 以外の要素で平均し、
+`type_logits` の Shape は `(..., N, len(ElementType))` です。Cross Entropy は Padding 以外の要素で平均し、
 座標誤差は有効な座標 Scalar で独立に平均します。その後、二つの Mean を `type_weight` と
 `coordinate_weight` で重み付けします。このため、Outline の長さや Padding 量が変化しても、
 相対的な重みが安定します。すべてが Padding の Input に対しては、微分可能なゼロ Loss を返します。
 
 この Loss は意図的に `reduction` Argument を持ちません。集約前の成分や異なる集約方法が
-必要な場合は、PyTorch の Cross Entropy と `coordinate_loss` を個別に使ってください。
+必要な場合は、PyTorch の Cross Entropy と `coordinate_mse_loss` を個別に使ってください。
 同等の関数 API は `torchfont.nn.functional.outline_loss` です。

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -72,8 +72,8 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | コンテナ | `Compose`, `RandomApply` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpath | `NormalizeSubpathStartPoints`, `RandomizeSubpathStartPoints`, `RandomizeSubpathOrder` |
-| 幾何変換 | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `RandomCoordJitter` |
+| Subpath | `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| 幾何変換 | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
 | 出力 | `RenderBitmap` |
 
 `RenderBitmap` は各 `Outline` を通常の `uint8` テンソルに変えます。これらが
@@ -143,7 +143,7 @@ Functional API は乱数を生成しません。ランダムな選択とパラ�
 | カーネル | 微分可能 |
 | --- | --- |
 | `affine` | はい |
-| `coord_jitter` | はい。Outline と Noise の両方について |
+| `add_coordinate_noise` | はい。Outline と Noise の両方について |
 | `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
 | `remove_overlaps`, `remove_overlap_groups` | いいえ |
@@ -171,7 +171,7 @@ Subpath の各 Transform と `RenderBitmap` は、CPU の `float32` Outline を�
 outline = outline.to("cpu", torch.float32)
 ```
 
-`RandomCoordJitter` と `functional.coord_jitter` は入力の Device と浮動小数点 dtype を
+`GaussianNoise` と `functional.add_coordinate_noise` は入力の Device と浮動小数点 dtype を
 維持します。
 
 ### `torch.compile`

--- a/src/dataset/discovered_font.rs
+++ b/src/dataset/discovered_font.rs
@@ -8,7 +8,7 @@ use skrifa::{
 };
 
 use crate::error::Error;
-use crate::font::{count_glyph_elements, map_font};
+use crate::font::{count_glyph_elements, map_font_file};
 
 /// One discovered face and the codepoint/glyph id pairs its `cmap` contributes.
 pub(crate) struct DiscoveredCodepoints {
@@ -149,7 +149,7 @@ fn read_faces<T>(
     path: &Path,
     build: impl Fn(u32, &skrifa::FontRef<'_>) -> Result<T, Error>,
 ) -> Result<Vec<T>, Error> {
-    let mapped = map_font(path)?;
+    let mapped = map_font_file(path)?;
     let parsed = FileRef::new(&mapped[..])
         .map_err(|err| Error::Parse(format!("failed to parse '{}': {err}", path.display())))?;
     let entries = parsed

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
-/// One discovered face: its file, TTC index, and the codepoint/glyph id pairs
+/// One discovered face: its file, face index, and the codepoint/glyph id pairs
 /// it contributes, sorted by codepoint.
 pub(crate) type IndexedCodepointFace = (PathBuf, u32, Vec<u32>, Vec<u32>);
 
-/// One discovered face: its file, TTC index, and the glyph ids it contributes,
+/// One discovered face: its file, face index, and the glyph ids it contributes,
 /// sorted in ascending order.
 pub(crate) type IndexedGlyphFace = (PathBuf, u32, Vec<u32>);
 

--- a/src/font/data.rs
+++ b/src/font/data.rs
@@ -4,7 +4,7 @@ use memmap2::Mmap;
 
 use crate::error::Error;
 
-pub(crate) fn map_font(path: &Path) -> Result<Mmap, Error> {
+pub(crate) fn map_font_file(path: &Path) -> Result<Mmap, Error> {
     let file = fs::File::open(path).map_err(|err| {
         Error::Io(std::io::Error::new(
             err.kind(),

--- a/src/font/extract.rs
+++ b/src/font/extract.rs
@@ -135,7 +135,7 @@ mod tests {
         raw::TableProvider as _,
     };
 
-    use crate::font::{map_font, parse_font_ref};
+    use crate::font::{map_font_file, parse_font_ref};
     use crate::outline::encode;
 
     use super::{count_glyph_elements, extract_glyph_outline};
@@ -144,7 +144,7 @@ mod tests {
     fn counts_the_elements_the_encoder_emits() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fonts/source-sans/SourceSans3-Regular.ttf");
-        let data = map_font(&path).unwrap();
+        let data = map_font_file(&path).unwrap();
         let font = parse_font_ref(&data[..], &path, 0).unwrap();
         let units_per_em = f32::from(font.head().unwrap().units_per_em());
         let settings = || DrawSettings::unhinted(Size::unscaled(), LocationRef::default());

--- a/src/font/location.rs
+++ b/src/font/location.rs
@@ -7,9 +7,9 @@ use crate::error::Error;
 #[derive(Clone)]
 pub(crate) struct AxisInfo {
     pub(crate) tag: String,
-    pub(crate) min: f32,
-    pub(crate) default: f32,
-    pub(crate) max: f32,
+    pub(crate) min_value: f32,
+    pub(crate) default_value: f32,
+    pub(crate) max_value: f32,
 }
 
 pub(crate) fn axis_info(font: &skrifa::FontRef<'_>) -> Vec<AxisInfo> {
@@ -17,9 +17,9 @@ pub(crate) fn axis_info(font: &skrifa::FontRef<'_>) -> Vec<AxisInfo> {
         .iter()
         .map(|axis| AxisInfo {
             tag: axis.tag().to_string(),
-            min: axis.min_value(),
-            default: axis.default_value(),
-            max: axis.max_value(),
+            min_value: axis.min_value(),
+            default_value: axis.default_value(),
+            max_value: axis.max_value(),
         })
         .collect()
 }
@@ -29,7 +29,7 @@ pub(crate) type Location = Vec<(String, f32)>;
 pub(crate) fn default_location(font: &skrifa::FontRef<'_>) -> Location {
     axis_info(font)
         .into_iter()
-        .map(|axis| (axis.tag, axis.default))
+        .map(|axis| (axis.tag, axis.default_value))
         .collect()
 }
 
@@ -55,17 +55,20 @@ pub(crate) fn canonicalize_location(
                 "variation axis '{tag}' value must be finite"
             )));
         }
-        if *value < axis.min || *value > axis.max {
+        if *value < axis.min_value || *value > axis.max_value {
             return Err(Error::Parse(format!(
                 "variation axis '{tag}' value {value} is outside [{}, {}]",
-                axis.min, axis.max,
+                axis.min_value, axis.max_value,
             )));
         }
     }
     Ok(axes
         .into_iter()
         .map(|axis| {
-            let value = location.get(&axis.tag).copied().unwrap_or(axis.default);
+            let value = location
+                .get(&axis.tag)
+                .copied()
+                .unwrap_or(axis.default_value);
             (axis.tag, value)
         })
         .collect())

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -3,7 +3,7 @@ mod extract;
 mod location;
 mod registered_axes;
 
-pub(crate) use data::{map_font, parse_font_ref};
+pub(crate) use data::{map_font_file, parse_font_ref};
 pub(crate) use extract::{count_glyph_elements, extract_glyph_outline};
 pub(crate) use location::{Location, axis_info, canonicalize_location};
 pub(crate) use registered_axes::registered_axis_values;

--- a/src/py/transform/load.rs
+++ b/src/py/transform/load.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::font::{
-    axis_info, canonicalize_location, map_font, parse_font_ref, registered_axis_values,
+    axis_info, canonicalize_location, map_font_file, parse_font_ref,
+    registered_axis_values as resolve_registered_axis_values,
 };
 use crate::transform::load::load_glyph_outline;
 
@@ -14,29 +15,29 @@ pub(crate) fn variation_axes(
     face_index: u32,
 ) -> PyResult<Vec<(String, f32, f32, f32)>> {
     py.detach(|| {
-        let data = map_font(&path)?;
+        let data = map_font_file(&path)?;
         let font = parse_font_ref(&data[..], &path, face_index)?;
         Ok(axis_info(&font)
             .into_iter()
-            .map(|axis| (axis.tag, axis.min, axis.default, axis.max))
+            .map(|axis| (axis.tag, axis.min_value, axis.default_value, axis.max_value))
             .collect())
     })
 }
 
-type GlyphTargets = (f32, f32, f32, f32, f32);
+type AxisValues = (f32, f32, f32, f32, f32);
 
 #[pyfunction]
-pub(crate) fn glyph_targets(
+pub(crate) fn registered_axis_values(
     py: Python<'_>,
     path: PathBuf,
     face_index: u32,
     location: BTreeMap<String, f32>,
-) -> PyResult<GlyphTargets> {
+) -> PyResult<AxisValues> {
     py.detach(|| {
-        let data = map_font(&path)?;
+        let data = map_font_file(&path)?;
         let font = parse_font_ref(&data[..], &path, face_index)?;
         let location = canonicalize_location(&font, &path, face_index, Some(&location))?;
-        let values = registered_axis_values(&font, &location);
+        let values = resolve_registered_axis_values(&font, &location);
         Ok((
             values.weight,
             values.width,

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -313,7 +313,7 @@ pub(crate) fn render_bitmap(
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load::load_glyph, m)?)?;
     m.add_function(wrap_pyfunction!(load::variation_axes, m)?)?;
-    m.add_function(wrap_pyfunction!(load::glyph_targets, m)?)?;
+    m.add_function(wrap_pyfunction!(load::registered_axis_values, m)?)?;
     m.add_function(wrap_pyfunction!(quad_to_cubic, m)?)?;
     m.add_function(wrap_pyfunction!(cubic_to_quad, m)?)?;
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;

--- a/src/transform/load.rs
+++ b/src/transform/load.rs
@@ -9,7 +9,7 @@ use skrifa::{
 
 use crate::{
     error::Error,
-    font::{canonicalize_location, extract_glyph_outline, map_font, parse_font_ref},
+    font::{canonicalize_location, extract_glyph_outline, map_font_file, parse_font_ref},
     outline::BezPath,
 };
 
@@ -19,7 +19,7 @@ pub(crate) fn load_glyph_outline(
     glyph_id: u32,
     location: Option<&BTreeMap<String, f32>>,
 ) -> Result<BezPath, Error> {
-    let data = map_font(path)?;
+    let data = map_font_file(path)?;
     let font = parse_font_ref(&data[..], path, face_index)?;
     let units_per_em = font
         .head()
@@ -67,7 +67,7 @@ mod tests {
 
     use crate::{
         error::Error,
-        font::{map_font, parse_font_ref},
+        font::{map_font_file, parse_font_ref},
     };
 
     use super::load_glyph_outline;
@@ -78,7 +78,7 @@ mod tests {
     }
 
     fn glyph_id_for(path: &Path, codepoint: u32) -> u32 {
-        let data = map_font(path).unwrap();
+        let data = map_font_file(path).unwrap();
         let font = parse_font_ref(&data[..], path, 0).unwrap();
         font.charmap().map(codepoint).unwrap().to_u32()
     }

--- a/tests/nn/test_embedding.py
+++ b/tests/nn/test_embedding.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torchfont import COORD_DIM, TYPE_DIM, ElementType, Outline
+from torchfont import ElementType, Outline
 from torchfont.nn import OutlineEmbedding
 
 
@@ -101,7 +101,7 @@ def test_outline_embedding_rejects_misaligned_tensors() -> None:
 
 def test_outline_embedding_initializes_both_branches_from_one_bound() -> None:
     embedding = OutlineEmbedding(1024)
-    bound = (TYPE_DIM + COORD_DIM) ** -0.5
+    bound = (len(ElementType) + 6) ** -0.5
     expected_std = bound / 3**0.5
     type_weight = embedding.type_embedding.weight.detach()[1:]
     coord_weight = embedding.coord_projection.weight.detach()

--- a/tests/nn/test_functional.py
+++ b/tests/nn/test_functional.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from torchfont import ElementType
-from torchfont.nn.functional import coordinate_loss
+from torchfont.nn.functional import coordinate_mse_loss
 
 
 def _types() -> torch.Tensor:
@@ -19,12 +19,12 @@ def _types() -> torch.Tensor:
     )
 
 
-def test_coordinate_loss_masks_inactive_coordinates() -> None:
+def test_coordinate_mse_loss_masks_inactive_coordinates() -> None:
     types = _types()
     prediction = torch.zeros((len(types), 6))
     target = torch.ones_like(prediction)
 
-    loss = coordinate_loss(prediction, types, target, reduction="none")
+    loss = coordinate_mse_loss(prediction, types, target, reduction="none")
 
     expected = torch.tensor(
         [
@@ -41,7 +41,7 @@ def test_coordinate_loss_masks_inactive_coordinates() -> None:
     assert torch.equal(loss, expected)
 
 
-def test_coordinate_loss_ignores_nonfinite_inactive_coordinates() -> None:
+def test_coordinate_mse_loss_ignores_nonfinite_inactive_coordinates() -> None:
     types = torch.tensor([ElementType.MOVE_TO, ElementType.PAD])
     prediction = torch.zeros((2, 6))
     target = torch.tensor(
@@ -51,7 +51,7 @@ def test_coordinate_loss_ignores_nonfinite_inactive_coordinates() -> None:
         ]
     )
 
-    loss = coordinate_loss(prediction, types, target, reduction="none")
+    loss = coordinate_mse_loss(prediction, types, target, reduction="none")
 
     assert torch.equal(
         loss,
@@ -59,11 +59,11 @@ def test_coordinate_loss_ignores_nonfinite_inactive_coordinates() -> None:
     )
 
 
-def test_coordinate_loss_mean_is_zero_without_active_coordinates() -> None:
+def test_coordinate_mse_loss_mean_is_zero_without_active_coordinates() -> None:
     types = torch.tensor([ElementType.CLOSE, ElementType.END, ElementType.PAD])
     prediction = torch.zeros((3, 6), requires_grad=True)
 
-    loss = coordinate_loss(prediction, types, torch.ones_like(prediction))
+    loss = coordinate_mse_loss(prediction, types, torch.ones_like(prediction))
     loss.backward()
 
     assert loss.item() == 0.0
@@ -71,21 +71,23 @@ def test_coordinate_loss_mean_is_zero_without_active_coordinates() -> None:
     assert torch.count_nonzero(prediction.grad) == 0
 
 
-def test_coordinate_loss_reductions_count_only_active_coordinates() -> None:
+def test_coordinate_mse_loss_reductions_count_only_active_coordinates() -> None:
     types = _types()
     prediction = torch.zeros((len(types), 6))
     target = torch.ones_like(prediction)
 
-    assert coordinate_loss(prediction, types, target).item() == 1.0
-    assert coordinate_loss(prediction, types, target, reduction="sum").item() == 14.0
+    assert coordinate_mse_loss(prediction, types, target).item() == 1.0
+    assert (
+        coordinate_mse_loss(prediction, types, target, reduction="sum").item() == 14.0
+    )
 
 
-def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> None:
+def test_coordinate_mse_loss_backpropagates_only_through_active_coordinates() -> None:
     types = torch.tensor([ElementType.QUAD_TO, ElementType.PAD])
     prediction = torch.zeros((2, 6), requires_grad=True)
     target = torch.ones_like(prediction)
 
-    coordinate_loss(prediction, types, target, reduction="sum").backward()
+    coordinate_mse_loss(prediction, types, target, reduction="sum").backward()
 
     grad = prediction.grad
     assert grad is not None
@@ -93,26 +95,26 @@ def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> Non
     assert torch.count_nonzero(grad[1]) == 0
 
 
-def test_coordinate_loss_rejects_a_prediction_that_does_not_match_the_target() -> None:
+def test_coordinate_mse_loss_rejects_prediction_shape_mismatch() -> None:
     target_types = torch.zeros(3, dtype=torch.long)
     target_coords = torch.zeros((3, 6))
 
     with pytest.raises(ValueError, match="same shape as the target coordinates"):
-        coordinate_loss(torch.zeros((2, 6)), target_types, target_coords)
+        coordinate_mse_loss(torch.zeros((2, 6)), target_types, target_coords)
 
 
-def test_coordinate_loss_rejects_misaligned_target_tensors() -> None:
+def test_coordinate_mse_loss_rejects_misaligned_target_tensors() -> None:
     with pytest.raises(ValueError, match="coords must have shape"):
-        coordinate_loss(
+        coordinate_mse_loss(
             torch.zeros((2, 6)),
             torch.zeros(1, dtype=torch.long),
             torch.zeros((2, 6)),
         )
 
 
-def test_coordinate_loss_rejects_invalid_reduction() -> None:
+def test_coordinate_mse_loss_rejects_invalid_reduction() -> None:
     with pytest.raises(ValueError, match="not a valid value"):
-        coordinate_loss(
+        coordinate_mse_loss(
             torch.zeros((1, 6)),
             torch.tensor([ElementType.MOVE_TO]),
             torch.zeros((1, 6)),

--- a/tests/nn/test_loss.py
+++ b/tests/nn/test_loss.py
@@ -2,13 +2,13 @@ import pytest
 import torch
 from torch.nn import functional as torch_functional
 
-from torchfont import TYPE_DIM, ElementType
+from torchfont import ElementType
 from torchfont.nn import OutlineLoss
 from torchfont.nn import functional as font_functional
 
 
 def _inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    type_logits = torch.zeros((3, TYPE_DIM), requires_grad=True)
+    type_logits = torch.zeros((3, len(ElementType)), requires_grad=True)
     coordinate_prediction = torch.zeros((3, 6), requires_grad=True)
     target_types = torch.tensor(
         [ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.PAD]
@@ -34,7 +34,7 @@ def test_outline_loss_combines_independently_averaged_losses() -> None:
         target_types,
         ignore_index=ElementType.PAD,
     )
-    expected_coord_loss = font_functional.coordinate_loss(
+    expected_coord_loss = font_functional.coordinate_mse_loss(
         prediction, target_types, target_coords
     )
     assert torch.allclose(loss, 2 * expected_type_loss + 3 * expected_coord_loss)
@@ -67,7 +67,7 @@ def test_outline_loss_backpropagates_through_both_predictions() -> None:
 
 
 def test_outline_loss_is_zero_for_all_padding() -> None:
-    type_logits = torch.zeros((2, TYPE_DIM), requires_grad=True)
+    type_logits = torch.zeros((2, len(ElementType)), requires_grad=True)
     prediction = torch.zeros((2, 6), requires_grad=True)
     target_types = torch.tensor([ElementType.PAD, ElementType.PAD])
     target_coords = torch.zeros_like(prediction)
@@ -85,8 +85,8 @@ def test_outline_loss_is_zero_for_all_padding() -> None:
 @pytest.mark.parametrize(
     ("logits_shape", "match"),
     [
-        ((2, 3, TYPE_DIM), "without its last dimension"),
-        ((3, TYPE_DIM - 1), "must have shape"),
+        ((2, 3, len(ElementType)), "without its last dimension"),
+        ((3, len(ElementType) - 1), "must have shape"),
     ],
 )
 def test_outline_loss_rejects_misaligned_type_logits(

--- a/tests/nn/test_outline_inputs.py
+++ b/tests/nn/test_outline_inputs.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from torch.nn.utils.rnn import pad_sequence
 
-from torchfont import COORD_DIM, TYPE_DIM, ElementType, Outline
+from torchfont import ElementType, Outline
 from torchfont.nn import OutlineEmbedding, OutlineLoss
 from torchfont.nn import functional as F  # noqa: N812
 
@@ -16,7 +16,7 @@ def _outline(length: int = 4) -> Outline:
         [ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.CLOSE, ElementType.END],
         dtype=torch.long,
     )[:length]
-    return Outline(types, torch.rand(length, COORD_DIM))
+    return Outline(types, torch.rand(length, 6))
 
 
 @pytest.fixture
@@ -47,17 +47,17 @@ def test_loss_accepts_batched_outline_tensors(
     batch: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = batch
-    logits = torch.zeros(*types.shape, TYPE_DIM)
+    logits = torch.zeros(*types.shape, len(ElementType))
 
     assert OutlineLoss()(logits, torch.zeros_like(coords), types, coords).ndim == 0
 
 
-def test_coordinate_loss_accepts_batched_outline_tensors(
+def test_coordinate_mse_loss_accepts_batched_outline_tensors(
     batch: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = batch
 
-    assert F.coordinate_loss(torch.zeros_like(coords), types, coords).ndim == 0
+    assert F.coordinate_mse_loss(torch.zeros_like(coords), types, coords).ndim == 0
 
 
 def test_loss_ignores_padding_introduced_by_pad_sequence() -> None:
@@ -69,13 +69,13 @@ def test_loss_ignores_padding_introduced_by_pad_sequence() -> None:
     )
     coords = pad_sequence([single.coords, single.coords], batch_first=True)
     padded_loss = OutlineLoss()(
-        torch.zeros(*types.shape, TYPE_DIM),
+        torch.zeros(*types.shape, len(ElementType)),
         torch.zeros_like(coords),
         types,
         coords,
     )
     unpadded_loss = OutlineLoss()(
-        torch.zeros(1, *single.shape, TYPE_DIM),
+        torch.zeros(1, *single.shape, len(ElementType)),
         torch.zeros(1, *single.coords.shape),
         single.types.unsqueeze(0),
         single.coords.unsqueeze(0),

--- a/tests/test_core_types.py
+++ b/tests/test_core_types.py
@@ -4,8 +4,6 @@ from torch.utils import _pytree as pytree
 
 import torchfont
 from torchfont import (
-    COORD_DIM,
-    TYPE_DIM,
     CodepointData,
     CodepointSample,
     ElementType,
@@ -18,8 +16,6 @@ from torchfont import (
 
 
 def test_core_types_are_exported_from_package_root() -> None:
-    assert torchfont.COORD_DIM == COORD_DIM
-    assert torchfont.TYPE_DIM == TYPE_DIM
     assert torchfont.ElementType is ElementType
     assert torchfont.FontRef is FontRef
     assert torchfont.CodepointData is CodepointData

--- a/tests/transforms/geometric/test_gaussian_noise.py
+++ b/tests/transforms/geometric/test_gaussian_noise.py
@@ -4,70 +4,68 @@ import pytest
 import torch
 
 from torchfont import ElementType, Outline
-from torchfont.transforms import RandomCoordJitter
-from torchfont.transforms.functional import coord_jitter
+from torchfont.transforms import GaussianNoise
+from torchfont.transforms.functional import add_coordinate_noise
 
 
-def test_random_coord_jitter_changes_only_active_coordinates(
+def test_gaussian_noise_changes_only_active_coordinates(
     quad_outline: tuple[torch.Tensor, torch.Tensor],
     close_end_zeros: Callable[[torch.Tensor, torch.Tensor], bool],
 ) -> None:
     types, coords = quad_outline
-    output = RandomCoordJitter(1.0)(Outline(types, coords))
+    output = GaussianNoise(1.0)(Outline(types, coords))
     quad_idx = types.tolist().index(ElementType.QUAD_TO.value)
     assert not torch.equal(output.coords[quad_idx, 0:2], coords[quad_idx, 0:2])
     assert output.coords[quad_idx, 2:4].tolist() == [0.0, 0.0]
     assert close_end_zeros(types, output.coords)
 
 
-def test_random_coord_jitter_zero_std_is_identity(
+def test_gaussian_noise_zero_sigma_is_identity(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*simple_outline)
-    output = RandomCoordJitter(0.0)(outline)
+    output = GaussianNoise(0.0)(outline)
     assert torch.equal(output.coords, outline.coords)
 
 
-def test_random_coord_jitter_shares_noise_between_outlines(
+def test_gaussian_noise_shares_noise_between_outlines(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*simple_outline)
-    first, second = RandomCoordJitter(0.1)([outline, outline])
+    first, second = GaussianNoise(0.1)([outline, outline])
     assert torch.equal(first.coords, second.coords)
 
 
-@pytest.mark.parametrize("std", [-0.1, float("nan"), float("inf")])
-def test_random_coord_jitter_rejects_invalid_std(std: float) -> None:
-    with pytest.raises(ValueError, match="std must be non-negative and finite"):
-        RandomCoordJitter(std)
+@pytest.mark.parametrize("sigma", [-0.1, float("nan"), float("inf")])
+def test_gaussian_noise_rejects_invalid_sigma(sigma: float) -> None:
+    with pytest.raises(ValueError, match="sigma must be non-negative and finite"):
+        GaussianNoise(sigma)
 
 
-def test_coord_jitter_accepts_noise_for_a_longer_outline(
+def test_add_coordinate_noise_accepts_noise_for_a_longer_outline(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*simple_outline)
     noise = torch.ones((len(outline.types) + 1, 3, 2))
 
-    output = coord_jitter(outline, noise)
+    output = add_coordinate_noise(outline, noise)
 
     assert output.coords.shape == outline.coords.shape
 
 
 @pytest.mark.parametrize("shape", [(1, 3, 2), (6, 6), (6, 2, 3)])
-def test_coord_jitter_rejects_incompatible_noise_shape(
+def test_add_coordinate_noise_rejects_incompatible_noise_shape(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
     shape: tuple[int, ...],
 ) -> None:
     with pytest.raises(ValueError, match="noise must"):
-        coord_jitter(Outline(*simple_outline), torch.ones(shape))
+        add_coordinate_noise(Outline(*simple_outline), torch.ones(shape))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_random_coord_jitter_preserves_cuda_device(
+def test_gaussian_noise_preserves_cuda_device(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
-    output = RandomCoordJitter(0.1)(
-        Outline(*(tensor.cuda() for tensor in simple_outline))
-    )
+    output = GaussianNoise(0.1)(Outline(*(tensor.cuda() for tensor in simple_outline)))
     assert output.types.device.type == "cuda"
     assert output.coords.device.type == "cuda"

--- a/tests/transforms/subpath/test_random_subpath_order.py
+++ b/tests/transforms/subpath/test_random_subpath_order.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from torchfont import ElementType, Outline
-from torchfont.transforms import RandomizeSubpathOrder
+from torchfont.transforms import RandomSubpathOrder
 from torchfont.transforms import functional as _functional
 
 
@@ -42,35 +42,35 @@ def two_squares() -> tuple[torch.Tensor, torch.Tensor]:
     return types, coords
 
 
-def test_randomize_subpath_order_is_reproducible(
+def test_random_subpath_order_is_reproducible(
     two_squares: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*two_squares)
     torch.manual_seed(4)
-    output1 = RandomizeSubpathOrder()(outline)
+    output1 = RandomSubpathOrder()(outline)
     torch.manual_seed(4)
-    output2 = RandomizeSubpathOrder()(outline)
+    output2 = RandomSubpathOrder()(outline)
     assert torch.equal(output1.types, output2.types)
     assert torch.equal(output1.coords, output2.coords)
 
 
-def test_randomize_subpath_order_preserves_rendering(
+def test_random_subpath_order_preserves_rendering(
     two_squares: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*two_squares)
     torch.manual_seed(4)
-    output = RandomizeSubpathOrder()(outline)
+    output = RandomSubpathOrder()(outline)
     before = _functional.render_bitmap(outline, size=64)
     after = _functional.render_bitmap(output, size=64)
     assert torch.equal(after, before)
 
 
-def test_randomize_subpath_order_preserves_each_subpath(
+def test_random_subpath_order_preserves_each_subpath(
     two_squares: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = two_squares
     torch.manual_seed(4)
-    output = RandomizeSubpathOrder()(Outline(types, coords))
+    output = RandomSubpathOrder()(Outline(types, coords))
     out_types, out_coords = output.types, output.coords
     input_blocks = {
         (tuple(types[:5].tolist()), tuple(coords[:5].flatten().tolist())),

--- a/tests/transforms/subpath/test_random_subpath_start_points.py
+++ b/tests/transforms/subpath/test_random_subpath_start_points.py
@@ -2,40 +2,40 @@ import pytest
 import torch
 
 from torchfont import Outline
-from torchfont.transforms import RandomizeSubpathStartPoints
+from torchfont.transforms import RandomSubpathStartPoints
 
 
-def test_randomize_subpath_start_points_is_reproducible(
+def test_random_subpath_start_points_is_reproducible(
     square: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = square
     torch.manual_seed(7)
-    out1 = RandomizeSubpathStartPoints()(Outline(types, coords))
+    out1 = RandomSubpathStartPoints()(Outline(types, coords))
     torch.manual_seed(7)
-    out2 = RandomizeSubpathStartPoints()(Outline(types, coords))
+    out2 = RandomSubpathStartPoints()(Outline(types, coords))
 
     assert torch.equal(out1.types, out2.types)
     assert torch.equal(out1.coords, out2.coords)
 
 
-def test_randomize_subpath_start_points_changes_start_endpoint(
+def test_random_subpath_start_points_changes_start_endpoint(
     square: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = square
 
     torch.manual_seed(0)
-    out_coords = RandomizeSubpathStartPoints()(Outline(types, coords)).coords
+    out_coords = RandomSubpathStartPoints()(Outline(types, coords)).coords
 
     assert out_coords[0, 4:6].tolist() == [2.0, 1.0]
 
 
-def test_randomize_subpath_start_points_leaves_open_subpaths_unchanged(
+def test_random_subpath_start_points_leaves_open_subpaths_unchanged(
     open_subpath: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = open_subpath
 
     torch.manual_seed(0)
-    output = RandomizeSubpathStartPoints()(Outline(types, coords))
+    output = RandomSubpathStartPoints()(Outline(types, coords))
     out_types, out_coords = output.types, output.coords
 
     assert torch.equal(out_types, types)
@@ -43,9 +43,9 @@ def test_randomize_subpath_start_points_leaves_open_subpaths_unchanged(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_randomize_subpath_start_points_rejects_cuda_input(
+def test_random_subpath_start_points_rejects_cuda_input(
     square: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = (tensor.cuda() for tensor in square)
     with pytest.raises(NotImplementedError, match="CUDA"):
-        RandomizeSubpathStartPoints()(Outline(types, coords))
+        RandomSubpathStartPoints()(Outline(types, coords))

--- a/tests/transforms/test_autograd.py
+++ b/tests/transforms/test_autograd.py
@@ -60,11 +60,11 @@ def test_affine_does_not_backpropagate_through_the_bbox_centre() -> None:
     assert torch.equal(coords.grad[active.detach()], torch.ones(int(active.sum())))
 
 
-def test_coord_jitter_is_differentiable_in_both_arguments() -> None:
+def test_add_coordinate_noise_is_differentiable_in_both_arguments() -> None:
     outline, coords = _grad_outline()
     noise = torch.zeros(5, 3, 2, requires_grad=True)
 
-    F.coord_jitter(outline, noise).coords.sum().backward()
+    F.add_coordinate_noise(outline, noise).coords.sum().backward()
 
     assert coords.grad is not None
     assert noise.grad is not None

--- a/torchfont/__init__.py
+++ b/torchfont/__init__.py
@@ -38,18 +38,11 @@ from torchfont._glyph import (
     GlyphIdSample,
     GlyphRef,
 )
-from torchfont._outline import (
-    COORD_DIM,
-    TYPE_DIM,
-    ElementType,
-    Outline,
-)
+from torchfont._outline import ElementType, Outline
 
 from . import datasets, glyphsets, nn, transforms
 
 __all__ = [
-    "COORD_DIM",
-    "TYPE_DIM",
     "CodepointData",
     "CodepointSample",
     "ElementType",

--- a/torchfont/_glyph.py
+++ b/torchfont/_glyph.py
@@ -18,7 +18,7 @@ T = TypeVar("T")
 _METRIC_FIELDS = ("weight", "width", "italic", "slant", "optical_size")
 
 
-class _MetricTargets(TypedDict):
+class _RegisteredAxisTargets(TypedDict):
     weight: float | None
     width: float | None
     italic: float | None
@@ -124,26 +124,26 @@ _register_glyph_payload(
 _register_glyph_payload(GlyphIdData, ("font_idx", *_METRIC_FIELDS))
 
 
-def _metric_targets(
-    metrics: tuple[float, float, float, float, float],
-) -> _MetricTargets:
-    """Build the continuous targets carried by a loaded glyph payload.
+def _registered_axis_targets(
+    values: tuple[float, float, float, float, float],
+) -> _RegisteredAxisTargets:
+    """Build registered-axis targets carried by a loaded glyph payload.
 
-    ``metrics`` is the ``(weight, width, italic, slant, optical_size)`` tuple
-    returned by the Rust ``glyph_targets`` helper, in that order.
+    ``values`` is the ``(weight, width, italic, slant, optical_size)`` tuple
+    returned by the Rust ``registered_axis_values`` helper, in that order.
     """
-    weight, width, italic, slant, optical_size = metrics
+    weight, width, italic, slant, optical_size = values
     return {
-        "weight": _optional_metric(weight),
-        "width": _optional_metric(width),
-        "italic": _optional_metric(italic),
-        "slant": _optional_metric(slant),
-        "optical_size": _optional_metric(optical_size),
+        "weight": _optional_target(weight),
+        "width": _optional_target(width),
+        "italic": _optional_target(italic),
+        "slant": _optional_target(slant),
+        "optical_size": _optional_target(optical_size),
     }
 
 
-def _optional_metric(value: float) -> float | None:
-    """Represent an unavailable native metric explicitly at the Python boundary."""
+def _optional_target(value: float) -> float | None:
+    """Represent an unavailable native target explicitly at the Python boundary."""
     return None if math.isnan(value) else value
 
 

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -31,7 +31,7 @@ import torch
 from torch import Tensor
 
 from torchfont import _torchfont
-from torchfont._outline import COORD_DIM
+from torchfont._outline import _COORD_DIM
 
 if TYPE_CHECKING:
     import numpy as np
@@ -60,7 +60,7 @@ def _restore(
     """Rebuild CPU tensors returned by the native kernel."""
     return (
         torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, COORD_DIM),
+        torch.from_numpy(out_coords).view(-1, _COORD_DIM),
     )
 
 
@@ -69,7 +69,7 @@ def _dynamic_outline(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     length = torch.library.get_ctx().new_dynamic_size()
     return (
         types.new_empty(length),
-        coords.new_empty(length, COORD_DIM),
+        coords.new_empty(length, _COORD_DIM),
     )
 
 

--- a/torchfont/_outline.py
+++ b/torchfont/_outline.py
@@ -34,8 +34,7 @@ class ElementType(IntEnum):
     END = 6
 
 
-TYPE_DIM: int = len(ElementType)
-COORD_DIM: int = 6
+_COORD_DIM = 6
 
 
 @dataclass(frozen=True, eq=False)
@@ -65,9 +64,12 @@ class Outline:
         if self.types.ndim != 1:
             msg = f"types must be 1-D, got {self.types.ndim}-D"
             raise ValueError(msg)
-        if self.coords.ndim != self.types.ndim + 1 or self.coords.shape[1] != COORD_DIM:
+        if (
+            self.coords.ndim != self.types.ndim + 1
+            or self.coords.shape[1] != _COORD_DIM
+        ):
             shape = tuple(self.coords.shape)
-            msg = f"coords must have shape (N, {COORD_DIM}), got {shape}"
+            msg = f"coords must have shape (N, {_COORD_DIM}), got {shape}"
             raise ValueError(msg)
         if self.types.shape[0] != self.coords.shape[0]:
             msg = (
@@ -165,8 +167,6 @@ class Outline:
 
 
 __all__ = [
-    "COORD_DIM",
-    "TYPE_DIM",
     "ElementType",
     "Outline",
 ]

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -85,7 +85,7 @@ def variation_axes(
     path: str,
     face_index: int,
 ) -> list[tuple[str, float, float, float]]: ...
-def glyph_targets(
+def registered_axis_values(
     path: str,
     face_index: int,
     location: dict[str, float],

--- a/torchfont/nn/_utils.py
+++ b/torchfont/nn/_utils.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
-from torchfont._outline import COORD_DIM, ElementType
+from torchfont._outline import _COORD_DIM, ElementType
 
 
 def _validate_outline_tensors(types: Tensor, coords: Tensor) -> None:
-    expected = (*types.shape, COORD_DIM)
+    expected = (*types.shape, _COORD_DIM)
     if coords.shape != expected:
         msg = f"coords must have shape {expected} for types, got {tuple(coords.shape)}"
         raise ValueError(msg)

--- a/torchfont/nn/functional.py
+++ b/torchfont/nn/functional.py
@@ -7,16 +7,17 @@ from typing import TYPE_CHECKING, Literal
 import torch
 from torch.nn import functional as _functional
 
-from torchfont._outline import TYPE_DIM, ElementType
+from torchfont._outline import ElementType
 from torchfont.nn._utils import _active_coordinate_mask, _validate_outline_tensors
 
 if TYPE_CHECKING:
     from torch import Tensor
 
 _Reduction = Literal["none", "mean", "sum"]
+_NUM_ELEMENT_TYPES = len(ElementType)
 
 
-def coordinate_loss(
+def coordinate_mse_loss(
     prediction: Tensor,
     target_types: Tensor,
     target_coords: Tensor,
@@ -71,20 +72,22 @@ def outline_loss(
             f"got {tuple(type_logits.shape)} and {tuple(target_types.shape)}"
         )
         raise ValueError(msg)
-    if type_logits.shape[-1] != TYPE_DIM:
-        msg = f"type_logits must have shape (..., N, {TYPE_DIM})"
+    if type_logits.shape[-1] != _NUM_ELEMENT_TYPES:
+        msg = f"type_logits must have shape (..., N, {_NUM_ELEMENT_TYPES})"
         raise ValueError(msg)
 
     type_loss = _functional.cross_entropy(
-        type_logits.reshape(-1, TYPE_DIM),
+        type_logits.reshape(-1, _NUM_ELEMENT_TYPES),
         target_types.reshape(-1),
         ignore_index=ElementType.PAD.value,
         reduction="sum",
     )
     type_count = (target_types != ElementType.PAD.value).sum().clamp_min(1)
     type_loss = type_loss / type_count
-    coords_loss = coordinate_loss(coordinate_prediction, target_types, target_coords)
+    coords_loss = coordinate_mse_loss(
+        coordinate_prediction, target_types, target_coords
+    )
     return type_weight * type_loss + coordinate_weight * coords_loss
 
 
-__all__ = ["coordinate_loss", "outline_loss"]
+__all__ = ["coordinate_mse_loss", "outline_loss"]

--- a/torchfont/nn/modules/embedding.py
+++ b/torchfont/nn/modules/embedding.py
@@ -7,8 +7,10 @@ import math
 import torch
 from torch import Tensor, nn
 
-from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType
+from torchfont._outline import _COORD_DIM, ElementType
 from torchfont.nn._utils import _active_coordinate_mask, _validate_outline_tensors
+
+_NUM_ELEMENT_TYPES = len(ElementType)
 
 
 class OutlineEmbedding(nn.Module):
@@ -30,14 +32,14 @@ class OutlineEmbedding(nn.Module):
         super().__init__()
         self.embedding_dim = embedding_dim
         self.type_embedding = nn.Embedding(
-            TYPE_DIM,
+            _NUM_ELEMENT_TYPES,
             embedding_dim,
             padding_idx=ElementType.PAD.value,
             device=device,
             dtype=dtype,
         )
         self.coord_projection = nn.Linear(
-            COORD_DIM,
+            _COORD_DIM,
             embedding_dim,
             bias=False,
             device=device,
@@ -47,7 +49,7 @@ class OutlineEmbedding(nn.Module):
 
     def reset_parameters(self) -> None:
         """Draw both branches from one uniform bound over the combined width."""
-        bound = 1 / math.sqrt(TYPE_DIM + COORD_DIM)
+        bound = 1 / math.sqrt(_NUM_ELEMENT_TYPES + _COORD_DIM)
         nn.init.uniform_(self.type_embedding.weight, -bound, bound)
         nn.init.uniform_(self.coord_projection.weight, -bound, bound)
         with torch.no_grad():

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -11,9 +11,9 @@ from torchfont.transforms._curves import (
 )
 from torchfont.transforms._geometry import (
     Affine,
+    GaussianNoise,
     HorizontalFlip,
     RandomAffine,
-    RandomCoordJitter,
     RandomHorizontalFlip,
     RandomVerticalFlip,
     VerticalFlip,
@@ -22,8 +22,8 @@ from torchfont.transforms._glyph import LoadGlyph
 from torchfont.transforms._outline import RandomRemoveOverlaps, RemoveOverlaps
 from torchfont.transforms._subpath import (
     NormalizeSubpathStartPoints,
-    RandomizeSubpathOrder,
-    RandomizeSubpathStartPoints,
+    RandomSubpathOrder,
+    RandomSubpathStartPoints,
 )
 from torchfont.transforms._transform import Transform
 
@@ -31,6 +31,7 @@ __all__ = [
     "Affine",
     "Compose",
     "CubicToQuad",
+    "GaussianNoise",
     "HorizontalFlip",
     "LoadGlyph",
     "MergeCurves",
@@ -38,13 +39,12 @@ __all__ = [
     "QuadToCubic",
     "RandomAffine",
     "RandomApply",
-    "RandomCoordJitter",
     "RandomHorizontalFlip",
     "RandomRemoveOverlaps",
     "RandomSplitSegments",
+    "RandomSubpathOrder",
+    "RandomSubpathStartPoints",
     "RandomVerticalFlip",
-    "RandomizeSubpathOrder",
-    "RandomizeSubpathStartPoints",
     "RemoveOverlaps",
     "RenderBitmap",
     "Transform",

--- a/torchfont/transforms/_geometry.py
+++ b/torchfont/transforms/_geometry.py
@@ -165,29 +165,29 @@ class RandomAffine(Transform):
         return _functional.affine(inpt, **params)
 
 
-class RandomCoordJitter(Transform):
+class GaussianNoise(Transform):
     """Add Gaussian coordinate noise to active outline elements."""
 
-    def __init__(self, std: float) -> None:
+    def __init__(self, sigma: float) -> None:
         super().__init__()
-        if not math.isfinite(std) or std < 0.0:
-            msg = "std must be non-negative and finite"
+        if not math.isfinite(sigma) or sigma < 0.0:
+            msg = "sigma must be non-negative and finite"
             raise ValueError(msg)
-        self.std = std
+        self.sigma = sigma
 
     def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
         length = max((inpt.coords.size(0) for inpt in flat_inputs), default=0)
-        return {"noise": torch.randn((length, 3, 2)) * self.std}
+        return {"noise": torch.randn((length, 3, 2)) * self.sigma}
 
     def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
-        return _functional.coord_jitter(inpt, params["noise"])
+        return _functional.add_coordinate_noise(inpt, params["noise"])
 
 
 __all__ = [
     "Affine",
+    "GaussianNoise",
     "HorizontalFlip",
     "RandomAffine",
-    "RandomCoordJitter",
     "RandomHorizontalFlip",
     "RandomVerticalFlip",
     "VerticalFlip",

--- a/torchfont/transforms/_glyph.py
+++ b/torchfont/transforms/_glyph.py
@@ -14,7 +14,7 @@ from torchfont._glyph import (
     GlyphIdData,
     GlyphIdSample,
     GlyphRef,
-    _metric_targets,
+    _registered_axis_targets,
 )
 from torchfont.transforms import functional as _functional
 
@@ -45,14 +45,16 @@ class LoadGlyph(nn.Module):
         outline = _functional.load_glyph(ref, location)
         if isinstance(inpt, GlyphRef):
             return outline
-        metrics = _torchfont.glyph_targets(ref.font.path, ref.font.face_index, location)
+        axis_values = _torchfont.registered_axis_values(
+            ref.font.path, ref.font.face_index, location
+        )
         if isinstance(inpt, GlyphIdSample):
             return GlyphIdData(
                 data=outline,
                 ref=ref,
                 location=location,
                 font_idx=inpt.font_idx,
-                **_metric_targets(metrics),
+                **_registered_axis_targets(axis_values),
             )
         return CodepointData(
             data=outline,
@@ -61,7 +63,7 @@ class LoadGlyph(nn.Module):
             codepoint=inpt.codepoint,
             font_idx=inpt.font_idx,
             character_idx=inpt.character_idx,
-            **_metric_targets(metrics),
+            **_registered_axis_targets(axis_values),
         )
 
     def extra_repr(self) -> str:

--- a/torchfont/transforms/_subpath.py
+++ b/torchfont/transforms/_subpath.py
@@ -34,13 +34,13 @@ class _RandomSubpathTransform(Transform):
         return self.function(inpt, params["values"])
 
 
-class RandomizeSubpathStartPoints(_RandomSubpathTransform):
+class RandomSubpathStartPoints(_RandomSubpathTransform):
     """Choose a random start point for every closed subpath."""
 
     function = staticmethod(_functional.set_subpath_start_points)
 
 
-class RandomizeSubpathOrder(_RandomSubpathTransform):
+class RandomSubpathOrder(_RandomSubpathTransform):
     """Randomly permute whole subpaths."""
 
     function = staticmethod(_functional.reorder_subpaths)
@@ -48,6 +48,6 @@ class RandomizeSubpathOrder(_RandomSubpathTransform):
 
 __all__ = [
     "NormalizeSubpathStartPoints",
-    "RandomizeSubpathOrder",
-    "RandomizeSubpathStartPoints",
+    "RandomSubpathOrder",
+    "RandomSubpathStartPoints",
 ]

--- a/torchfont/transforms/functional/__init__.py
+++ b/torchfont/transforms/functional/__init__.py
@@ -8,8 +8,8 @@ from torchfont.transforms.functional._curves import (
     split_segments,
 )
 from torchfont.transforms.functional._geometry import (
+    add_coordinate_noise,
     affine,
-    coord_jitter,
     horizontal_flip,
     vertical_flip,
 )
@@ -25,8 +25,8 @@ from torchfont.transforms.functional._subpath import (
 )
 
 __all__ = [
+    "add_coordinate_noise",
     "affine",
-    "coord_jitter",
     "cubic_to_quad",
     "horizontal_flip",
     "load_glyph",

--- a/torchfont/transforms/functional/_geometry.py
+++ b/torchfont/transforms/functional/_geometry.py
@@ -278,7 +278,7 @@ def affine(
     )
 
 
-def coord_jitter(inpt: Outline, noise: Tensor) -> Outline:
+def add_coordinate_noise(inpt: Outline, noise: Tensor) -> Outline:
     """Add caller-provided noise to active coordinate pairs.
 
     Differentiable with respect to both ``coords`` and ``noise``.
@@ -302,4 +302,4 @@ def coord_jitter(inpt: Outline, noise: Tensor) -> Outline:
     )
 
 
-__all__ = ["affine", "coord_jitter", "horizontal_flip", "vertical_flip"]
+__all__ = ["add_coordinate_noise", "affine", "horizontal_flip", "vertical_flip"]

--- a/torchfont/transforms/functional/_glyph.py
+++ b/torchfont/transforms/functional/_glyph.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 
 from torchfont import _torchfont
-from torchfont._outline import COORD_DIM, Outline
+from torchfont._outline import _COORD_DIM, Outline
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -33,7 +33,7 @@ def load_glyph(
     )
     return Outline._wrap(  # noqa: SLF001
         torch.from_numpy(raw_types),
-        torch.from_numpy(raw_coords).view(-1, COORD_DIM),
+        torch.from_numpy(raw_coords).view(-1, _COORD_DIM),
     )
 
 


### PR DESCRIPTION
## Summary

- replace ambiguous coordinate-jitter and subpath-randomization names with PyTorch/TorchVision-style transform names
- rename the coordinate regression loss to `coordinate_mse_loss` and remove fixed encoding dimensions from the public API
- align private font and variation-axis terminology with Skrifa/read-fonts concepts
- update tests and the English/Japanese API reference without compatibility aliases

## Validation

- `mise run check`
- `mise run test` (391 passed, 12 skipped)
- `mise run docs-build`
- `git diff --check`