### PR TITLE
Validate infinite affine parameters

### DIFF
--- a/tests/transforms/geometric/test_affine.py
+++ b/tests/transforms/geometric/test_affine.py
@@ -110,20 +110,24 @@ def test_affine_invalid_scale_raises(
         affine(types, coords, scale=scale)
 
 
-def test_affine_rejects_nan_angle(
+@pytest.mark.parametrize("angle", [float("nan"), float("inf"), float("-inf")])
+def test_affine_rejects_non_finite_angle(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
+    angle: float,
 ) -> None:
     types, coords = simple_outline
     with pytest.raises(ValueError, match="angle must be finite"):
-        affine(types, coords, angle=float("nan"))
+        affine(types, coords, angle=angle)
 
 
-def test_affine_rejects_nan_shear(
+@pytest.mark.parametrize("shear", [float("nan"), float("inf"), float("-inf")])
+def test_affine_rejects_non_finite_shear(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
+    shear: float,
 ) -> None:
     types, coords = simple_outline
     with pytest.raises(ValueError, match="shear must be finite"):
-        affine(types, coords, shear=float("nan"))
+        affine(types, coords, shear=shear)
 
 
 @pytest.mark.parametrize(

--- a/torchfont/transforms/functional/_geometry.py
+++ b/torchfont/transforms/functional/_geometry.py
@@ -210,10 +210,10 @@ def _affine(
     if _is_nan(scale) or _is_infinite(scale) or scale <= 0:
         msg = "scale must be positive and finite"
         raise ValueError(msg)
-    if _is_nan(angle):
+    if _is_nan(angle) or _is_infinite(angle):
         msg = "angle must be finite"
         raise ValueError(msg)
-    if _is_nan(shear):
+    if _is_nan(shear) or _is_infinite(shear):
         msg = "shear must be finite"
         raise ValueError(msg)
     if any(_is_nan(value) or _is_infinite(value) for value in translate):


### PR DESCRIPTION
Reject positive and negative infinity for affine angle and shear parameters at the public functional boundary.

Add regression coverage for NaN and both infinities.

## Validation
- `uv run --locked --no-sync pytest tests`
- `mise run --force python-check`