### PR TITLE
Add subpath splitting transform

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -73,13 +73,17 @@ inside an already-applied transform.
 | Containers | `Compose`, `RandomApply` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpaths | `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpaths | `SplitSubpaths`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | Geometry | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
 | Output | `RenderBitmap` |
 
 `RenderBitmap` changes each `Outline` leaf into a plain `uint8` tensor. When
 these leaves are inside `CodepointData` or `GlyphIdData`, its reference, location,
 and targets remain alongside the converted payload.
+
+`SplitSubpaths` changes each `Outline` into a `tuple[Outline, ...]` of
+independently encoded subpaths. Later transforms in a `Compose` process every
+resulting subpath.
 
 ### Using rendered glyphs with TorchVision
 
@@ -150,7 +154,7 @@ Gradient support varies by operation:
 | `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
 | `remove_overlaps`, `remove_overlap_groups` | no |
-| `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
+| `split_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
 | `render_bitmap` | no |
 
 Passing an outline that requires grad to an operation marked "no" raises:

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -72,13 +72,17 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | コンテナ | `Compose`, `RandomApply` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpath | `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpath | `SplitSubpaths`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | 幾何変換 | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
 | 出力 | `RenderBitmap` |
 
 `RenderBitmap` は各 `Outline` を通常の `uint8` テンソルに変えます。これらが
 `CodepointData` や `GlyphIdData` の中にある場合も、参照、Location、Target は変換後の Payload と
 ともに維持されます。
+
+`SplitSubpaths` は各 `Outline` を、独立してエンコードされた Subpath の
+`tuple[Outline, ...]` に変えます。`Compose` 内の後続 Transform は、分割された各
+Subpath を処理します。
 
 ### レンダリングしたグリフを TorchVision で使う
 
@@ -147,7 +151,7 @@ Functional API は乱数を生成しません。ランダムな選択とパラ�
 | `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
 | `remove_overlaps`, `remove_overlap_groups` | いいえ |
-| `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
+| `split_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
 | `render_bitmap` | いいえ |
 
 「いいえ」の処理に勾配を要求する Outline を渡すとエラーになります。

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -39,6 +39,19 @@ fn encode<'py>(py: Python<'py>, outline: &BezPath) -> OutlineArrays<'py> {
 }
 
 #[pyfunction]
+pub(crate) fn split_subpaths<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<Vec<OutlineArrays<'py>>> {
+    let outline = decode(types.as_slice()?, coords.as_slice()?)?;
+    Ok(subpath::split_subpaths(&outline)
+        .iter()
+        .map(|subpath| encode(py, subpath))
+        .collect())
+}
+
+#[pyfunction]
 pub(crate) fn quad_to_cubic<'py>(
     py: Python<'py>,
     types: PyReadonlyArray1<'_, i64>,
@@ -318,6 +331,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cubic_to_quad, m)?)?;
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;
     m.add_function(wrap_pyfunction!(random_split_segments, m)?)?;
+    m.add_function(wrap_pyfunction!(split_subpaths, m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(random_remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -9,6 +9,13 @@ pub(crate) fn reverse_subpath(subpath: &[PathEl]) -> BezPath {
     BezPath::from_vec(subpath.to_vec()).reverse_subpaths()
 }
 
+pub(crate) fn split_subpaths(outline: &BezPath) -> Vec<BezPath> {
+    outline
+        .subpaths()
+        .map(|subpath| BezPath::from_vec(subpath.to_vec()))
+        .collect()
+}
+
 pub(crate) fn normalize_subpath_start_points(outline: &BezPath) -> BezPath {
     transform_start_points(outline, |subpath, _| {
         nodes(subpath)
@@ -135,6 +142,15 @@ mod tests {
     }
 
     // --- reverse_subpath ---
+
+    #[test]
+    fn splits_subpaths_in_order() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(2.0, 0.0), vec![line(3.0, 0.0)]);
+        let outline = outline_from_subpaths([first.clone(), second.clone()]);
+
+        assert_eq!(split_subpaths(&outline), [first, second]);
+    }
 
     #[test]
     fn reverse_subpath_empty_returns_clone() {

--- a/tests/transforms/subpath/test_split_subpaths.py
+++ b/tests/transforms/subpath/test_split_subpaths.py
@@ -1,0 +1,102 @@
+import pytest
+import torch
+
+from torchfont import ElementType, Outline
+from torchfont.transforms import Affine, Compose, SplitSubpaths, functional
+
+
+def _outline(types: list[ElementType]) -> Outline:
+    type_tensor = torch.tensor(types, dtype=torch.long)
+    coords = torch.arange(len(types) * 6, dtype=torch.float32).view(-1, 6)
+    return Outline(type_tensor, coords)
+
+
+def test_split_subpaths_returns_independent_encodings() -> None:
+    outline = _outline(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.CLOSE,
+            ElementType.MOVE_TO,
+            ElementType.QUAD_TO,
+            ElementType.END,
+        ]
+    )
+
+    first, second = functional.split_subpaths(outline)
+
+    assert first.types.tolist() == [
+        ElementType.MOVE_TO,
+        ElementType.LINE_TO,
+        ElementType.CLOSE,
+        ElementType.END,
+    ]
+    assert second.types.tolist() == [
+        ElementType.MOVE_TO,
+        ElementType.QUAD_TO,
+        ElementType.END,
+    ]
+    assert torch.equal(first.coords[:2, 4:6], outline.coords[:2, 4:6])
+    assert torch.equal(second.coords[0, 4:6], outline.coords[3, 4:6])
+    assert torch.equal(second.coords[1, (0, 1, 4, 5)], outline.coords[4, (0, 1, 4, 5)])
+    assert torch.count_nonzero(first.coords[2]) == 0
+    assert torch.count_nonzero(first.coords[-1]) == 0
+
+
+def test_split_subpaths_rejects_coordinate_gradients() -> None:
+    outline = _outline([ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END])
+    outline.coords.requires_grad_()
+
+    with pytest.raises(RuntimeError, match=r"split_subpaths.*not differentiable"):
+        functional.split_subpaths(outline)
+
+
+def test_split_subpaths_returns_empty_tuple_without_subpaths() -> None:
+    outline = _outline([ElementType.END])
+
+    assert functional.split_subpaths(outline) == ()
+
+
+def test_split_subpaths_rejects_an_element_outside_subpath() -> None:
+    outline = _outline([ElementType.LINE_TO, ElementType.END])
+
+    with pytest.raises(ValueError, match="requires a preceding MOVE_TO"):
+        functional.split_subpaths(outline)
+
+
+def test_split_subpaths_transform_preserves_enclosing_data() -> None:
+    outline = _outline(
+        [
+            ElementType.MOVE_TO,
+            ElementType.CLOSE,
+            ElementType.MOVE_TO,
+            ElementType.CLOSE,
+            ElementType.END,
+        ]
+    )
+
+    result = SplitSubpaths()({"outline": outline, "label": 4})
+
+    assert result["label"] == 4
+    assert isinstance(result["outline"], tuple)
+    assert len(result["outline"]) == 2
+
+
+def test_following_transform_processes_each_subpath() -> None:
+    outline = _outline(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.END,
+        ]
+    )
+
+    subpaths = Compose([SplitSubpaths(), Affine(angle=10.0)])(outline)
+
+    assert len(subpaths) == 2
+    assert all(isinstance(subpath, Outline) for subpath in subpaths)
+    assert all(
+        not torch.equal(subpath.coords[:-1], outline.coords[:2]) for subpath in subpaths
+    )

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -22,6 +22,9 @@ def random_split_segments(
     split_probability: float,
     split_range: tuple[float, float],
 ) -> tuple[np.ndarray, np.ndarray]: ...
+def split_subpaths(
+    types: np.ndarray, coords: np.ndarray
+) -> list[tuple[np.ndarray, np.ndarray]]: ...
 def render_bitmap(
     types: np.ndarray,
     coords: np.ndarray,

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -24,6 +24,7 @@ from torchfont.transforms._subpath import (
     NormalizeSubpathStartPoints,
     RandomSubpathOrder,
     RandomSubpathStartPoints,
+    SplitSubpaths,
 )
 from torchfont.transforms._transform import Transform
 
@@ -47,6 +48,7 @@ __all__ = [
     "RandomVerticalFlip",
     "RemoveOverlaps",
     "RenderBitmap",
+    "SplitSubpaths",
     "Transform",
     "VerticalFlip",
     "functional",

--- a/torchfont/transforms/_subpath.py
+++ b/torchfont/transforms/_subpath.py
@@ -23,6 +23,14 @@ class NormalizeSubpathStartPoints(Transform):
         return _functional.normalize_subpath_start_points(inpt)
 
 
+class SplitSubpaths(Transform):
+    """Split each outline into a tuple of independently encoded subpaths."""
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> tuple[Outline, ...]:
+        del params
+        return _functional.split_subpaths(inpt)
+
+
 class _RandomSubpathTransform(Transform):
     function: ClassVar[Callable[..., Outline]]
 
@@ -50,4 +58,5 @@ __all__ = [
     "NormalizeSubpathStartPoints",
     "RandomSubpathOrder",
     "RandomSubpathStartPoints",
+    "SplitSubpaths",
 ]

--- a/torchfont/transforms/functional/__init__.py
+++ b/torchfont/transforms/functional/__init__.py
@@ -22,6 +22,7 @@ from torchfont.transforms.functional._subpath import (
     normalize_subpath_start_points,
     reorder_subpaths,
     set_subpath_start_points,
+    split_subpaths,
 )
 
 __all__ = [
@@ -39,5 +40,6 @@ __all__ = [
     "reorder_subpaths",
     "set_subpath_start_points",
     "split_segments",
+    "split_subpaths",
     "vertical_flip",
 ]

--- a/torchfont/transforms/functional/_subpath.py
+++ b/torchfont/transforms/functional/_subpath.py
@@ -1,21 +1,46 @@
-"""Functional subpath kernels.
+"""Functional subpath operations.
 
-Every kernel here reorders or re-encodes path elements in Rust, so none of them
-define a gradient. Subpath boundaries are derived from the ``CLOSE`` and ``END``
-element types rather than stored alongside the outline.
+Subpath boundaries are derived from path element types rather than stored
+alongside the outline. Operations here reorder or re-encode elements in Rust,
+so they do not define a gradient.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from torchfont import _ops
-from torchfont.transforms.functional._utils import _native_outline
+import torch
+
+from torchfont import _ops, _torchfont
+from torchfont._outline import _COORD_DIM, Outline
+from torchfont.transforms.functional._utils import _native_outline, _require_no_grad
 
 if TYPE_CHECKING:
     from torch import Tensor
 
-    from torchfont._outline import Outline
+
+def split_subpaths(inpt: Outline) -> tuple[Outline, ...]:
+    """Split an outline into independently encoded subpaths.
+
+    Each result starts with ``MOVE_TO`` and ends with a newly added ``END``.
+    Subpath order, winding, curve degree, coordinates, and whether the subpath
+    is open or closed are preserved. An outline with no subpaths returns an
+    empty tuple.
+
+    The number of results depends on tensor values, so this operation is not
+    supported inside :func:`torch.compile`.
+    """
+    _require_no_grad(inpt, "split_subpaths")
+    arrays = _torchfont.split_subpaths(
+        inpt.types.detach().contiguous().numpy(),
+        inpt.coords.detach().contiguous().reshape(-1).numpy(),
+    )
+    return tuple(
+        Outline._wrap(  # noqa: SLF001
+            torch.from_numpy(types), torch.from_numpy(coords).view(-1, _COORD_DIM)
+        )
+        for types, coords in arrays
+    )
 
 
 def normalize_subpath_start_points(inpt: Outline) -> Outline:
@@ -57,4 +82,5 @@ __all__ = [
     "normalize_subpath_start_points",
     "reorder_subpaths",
     "set_subpath_start_points",
+    "split_subpaths",
 ]


### PR DESCRIPTION
## Summary

- add `SplitSubpaths` and `functional.split_subpaths`, returning `tuple[Outline, ...]`
- split and re-encode subpaths in the Rust backend
- preserve nested transform composition so later transforms process each subpath
- document the public API in English and Japanese

## Validation

- `mise run check`
- `mise run build`
- `mise run test` (401 passed, 12 skipped)
- `mise run docs-build`
