### PR TITLE
Add random subpath dropout transform

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -73,7 +73,7 @@ inside an already-applied transform.
 | Containers | `Compose`, `RandomApply` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpaths | `SplitSubpaths`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpaths | `SplitSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | Geometry | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
 | Output | `RenderBitmap` |
 
@@ -154,7 +154,7 @@ Gradient support varies by operation:
 | `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
 | `remove_overlaps`, `remove_overlap_groups` | no |
-| `split_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
+| `split_subpaths`, `drop_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
 | `render_bitmap` | no |
 
 Passing an outline that requires grad to an operation marked "no" raises:

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -72,7 +72,7 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | コンテナ | `Compose`, `RandomApply` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpath | `SplitSubpaths`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpath | `SplitSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | 幾何変換 | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
 | 出力 | `RenderBitmap` |
 
@@ -151,7 +151,7 @@ Functional API は乱数を生成しません。ランダムな選択とパラ�
 | `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
 | `remove_overlaps`, `remove_overlap_groups` | いいえ |
-| `split_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
+| `split_subpaths`, `drop_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
 | `render_bitmap` | いいえ |
 
 「いいえ」の処理に勾配を要求する Outline を渡すとエラーになります。

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -52,6 +52,25 @@ pub(crate) fn split_subpaths<'py>(
 }
 
 #[pyfunction]
+pub(crate) fn drop_subpaths<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+    drop_mask: PyReadonlyArray1<'_, bool>,
+) -> PyResult<OutlineArrays<'py>> {
+    let outline = decode(types.as_slice()?, coords.as_slice()?)?;
+    let drop_mask = drop_mask.as_slice()?;
+    let subpath_count = outline.subpaths().count();
+    if drop_mask.len() < subpath_count {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "drop_mask length must be at least the number of subpaths",
+        ));
+    }
+    let result = py.detach(|| subpath::drop_subpaths(&outline, drop_mask));
+    Ok(encode(py, &result))
+}
+
+#[pyfunction]
 pub(crate) fn quad_to_cubic<'py>(
     py: Python<'py>,
     types: PyReadonlyArray1<'_, i64>,
@@ -332,6 +351,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;
     m.add_function(wrap_pyfunction!(random_split_segments, m)?)?;
     m.add_function(wrap_pyfunction!(split_subpaths, m)?)?;
+    m.add_function(wrap_pyfunction!(drop_subpaths, m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(random_remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -16,6 +16,16 @@ pub(crate) fn split_subpaths(outline: &BezPath) -> Vec<BezPath> {
         .collect()
 }
 
+pub(crate) fn drop_subpaths(outline: &BezPath, drop_mask: &[bool]) -> BezPath {
+    let mut result = BezPath::new();
+    for (subpath, &drop) in outline.subpaths().zip(drop_mask) {
+        if !drop {
+            result.extend(subpath.iter().copied());
+        }
+    }
+    result
+}
+
 pub(crate) fn normalize_subpath_start_points(outline: &BezPath) -> BezPath {
     transform_start_points(outline, |subpath, _| {
         nodes(subpath)
@@ -150,6 +160,16 @@ mod tests {
         let outline = outline_from_subpaths([first.clone(), second.clone()]);
 
         assert_eq!(split_subpaths(&outline), [first, second]);
+    }
+
+    #[test]
+    fn drops_selected_subpaths() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(2.0, 0.0), vec![line(3.0, 0.0)]);
+        let outline = outline_from_subpaths([first.clone(), second]);
+
+        assert_eq!(drop_subpaths(&outline, &[false, true]), first);
+        assert!(drop_subpaths(&outline, &[true, true]).is_empty());
     }
 
     #[test]

--- a/tests/transforms/subpath/test_random_subpath_dropout.py
+++ b/tests/transforms/subpath/test_random_subpath_dropout.py
@@ -1,0 +1,91 @@
+import pytest
+import torch
+
+from torchfont import ElementType, Outline
+from torchfont.transforms import RandomSubpathDropout, functional
+
+
+@pytest.fixture
+def two_lines() -> Outline:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.END,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(5, 6)
+    coords[0, 4:6] = torch.tensor([0.0, 0.0])
+    coords[1, 4:6] = torch.tensor([1.0, 0.0])
+    coords[2, 4:6] = torch.tensor([2.0, 0.0])
+    coords[3, 4:6] = torch.tensor([3.0, 0.0])
+    return Outline(types, coords)
+
+
+def test_drop_subpaths_uses_explicit_selection_values(two_lines: Outline) -> None:
+    output = functional.drop_subpaths(
+        two_lines,
+        torch.tensor([True, False]),
+    )
+
+    assert output.types.tolist() == [
+        ElementType.MOVE_TO,
+        ElementType.LINE_TO,
+        ElementType.END,
+    ]
+    assert output.coords[0, 4].item() == 2.0
+
+
+@pytest.mark.parametrize(("p", "subpath_count"), [(0.0, 2), (1.0, 0)])
+def test_random_subpath_dropout_probability_boundaries(
+    two_lines: Outline, p: float, subpath_count: int
+) -> None:
+    output = RandomSubpathDropout(p)(two_lines)
+
+    assert output.types.tolist().count(ElementType.MOVE_TO) == subpath_count
+    assert output.types[-1].item() == ElementType.END
+
+
+def test_random_subpath_dropout_is_reproducible(two_lines: Outline) -> None:
+    torch.manual_seed(0)
+    first = RandomSubpathDropout(0.5)(two_lines)
+    torch.manual_seed(0)
+    second = RandomSubpathDropout(0.5)(two_lines)
+
+    assert torch.equal(first.types, second.types)
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_random_subpath_dropout_shares_selection_between_outlines(
+    two_lines: Outline,
+) -> None:
+    first, second = RandomSubpathDropout(0.5)([two_lines, two_lines])
+
+    assert torch.equal(first.types, second.types)
+    assert torch.equal(first.coords, second.coords)
+
+
+@pytest.mark.parametrize("p", [-0.1, 1.1])
+def test_random_subpath_dropout_rejects_invalid_probability(p: float) -> None:
+    with pytest.raises(ValueError, match="p must be between 0 and 1"):
+        RandomSubpathDropout(p)
+
+
+def test_random_subpath_dropout_uses_pytorch_default() -> None:
+    assert repr(RandomSubpathDropout()) == "RandomSubpathDropout(p=0.5)"
+
+
+def test_drop_subpaths_rejects_too_short_mask(two_lines: Outline) -> None:
+    with pytest.raises(ValueError, match="at least the number of subpaths"):
+        functional.drop_subpaths(
+            two_lines,
+            torch.tensor([False]),
+        )
+
+
+def test_drop_subpaths_requires_boolean_mask(two_lines: Outline) -> None:
+    with pytest.raises(TypeError, match=r"mask must have dtype torch\.bool"):
+        functional.drop_subpaths(two_lines, torch.tensor([0, 1]))

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -71,6 +71,7 @@ def _cases() -> list[tuple[str, CustomOpDef, tuple[object, ...]]]:
         ("bbox_center", ops.bbox_center, pair),
         ("set_subpath_start_points", ops.set_subpath_start_points, (*pair, values)),
         ("reorder_subpaths", ops.reorder_subpaths, (*pair, values)),
+        ("drop_subpaths", ops.drop_subpaths, (*pair, values < 0.5)),
         ("remove_overlap_groups", ops.remove_overlap_groups, (*pair, values)),
         (
             "split_segments",

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -80,6 +80,13 @@ def _selection(values: Tensor) -> np.ndarray:
     return values.detach().contiguous().numpy()
 
 
+def _mask(values: Tensor) -> np.ndarray:
+    if values.dtype is not torch.bool:
+        msg = f"mask must have dtype torch.bool, got {values.dtype}"
+        raise TypeError(msg)
+    return values.detach().contiguous().numpy()
+
+
 @torch.library.custom_op(
     "torchfont::quad_to_cubic", mutates_args=(), device_types="cpu"
 )
@@ -259,6 +266,32 @@ def _(types: Tensor, coords: Tensor, keys: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
+    "torchfont::drop_subpaths", mutates_args=(), device_types="cpu"
+)
+def drop_subpaths(
+    types: Tensor,
+    coords: Tensor,
+    drop_mask: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Drop subpaths selected by an explicit boolean mask."""
+    out = _torchfont.drop_subpaths(
+        *_arrays(types, coords),
+        _mask(drop_mask),
+    )
+    return _restore(*out)
+
+
+@drop_subpaths.register_fake
+def _(
+    types: Tensor,
+    coords: Tensor,
+    drop_mask: Tensor,
+) -> tuple[Tensor, Tensor]:
+    del drop_mask
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
     "torchfont::reverse_closed_subpaths", mutates_args=(), device_types="cpu"
 )
 def reverse_closed_subpaths(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
@@ -339,6 +372,7 @@ def _(
 __all__ = [
     "bbox_center",
     "cubic_to_quad",
+    "drop_subpaths",
     "merge_curves",
     "normalize_subpath_start_points",
     "quad_to_cubic",

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -25,6 +25,11 @@ def random_split_segments(
 def split_subpaths(
     types: np.ndarray, coords: np.ndarray
 ) -> list[tuple[np.ndarray, np.ndarray]]: ...
+def drop_subpaths(
+    types: np.ndarray,
+    coords: np.ndarray,
+    drop_mask: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]: ...
 def render_bitmap(
     types: np.ndarray,
     coords: np.ndarray,

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -22,6 +22,7 @@ from torchfont.transforms._glyph import LoadGlyph
 from torchfont.transforms._outline import RandomRemoveOverlaps, RemoveOverlaps
 from torchfont.transforms._subpath import (
     NormalizeSubpathStartPoints,
+    RandomSubpathDropout,
     RandomSubpathOrder,
     RandomSubpathStartPoints,
     SplitSubpaths,
@@ -43,6 +44,7 @@ __all__ = [
     "RandomHorizontalFlip",
     "RandomRemoveOverlaps",
     "RandomSplitSegments",
+    "RandomSubpathDropout",
     "RandomSubpathOrder",
     "RandomSubpathStartPoints",
     "RandomVerticalFlip",

--- a/torchfont/transforms/_subpath.py
+++ b/torchfont/transforms/_subpath.py
@@ -31,6 +31,27 @@ class SplitSubpaths(Transform):
         return _functional.split_subpaths(inpt)
 
 
+class RandomSubpathDropout(Transform):
+    """Drop each subpath independently with probability ``p``."""
+
+    def __init__(self, p: float = 0.5) -> None:
+        super().__init__()
+        if not 0.0 <= p <= 1.0:
+            msg = "p must be between 0 and 1"
+            raise ValueError(msg)
+        self.p = p
+
+    def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
+        length = max((inpt.types.size(0) for inpt in flat_inputs), default=0)
+        return {"drop_mask": torch.rand(length) < self.p}
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        return _functional.drop_subpaths(
+            inpt,
+            params["drop_mask"],
+        )
+
+
 class _RandomSubpathTransform(Transform):
     function: ClassVar[Callable[..., Outline]]
 
@@ -56,6 +77,7 @@ class RandomSubpathOrder(_RandomSubpathTransform):
 
 __all__ = [
     "NormalizeSubpathStartPoints",
+    "RandomSubpathDropout",
     "RandomSubpathOrder",
     "RandomSubpathStartPoints",
     "SplitSubpaths",

--- a/torchfont/transforms/functional/__init__.py
+++ b/torchfont/transforms/functional/__init__.py
@@ -19,6 +19,7 @@ from torchfont.transforms.functional._outline import (
     remove_overlaps,
 )
 from torchfont.transforms.functional._subpath import (
+    drop_subpaths,
     normalize_subpath_start_points,
     reorder_subpaths,
     set_subpath_start_points,
@@ -29,6 +30,7 @@ __all__ = [
     "add_coordinate_noise",
     "affine",
     "cubic_to_quad",
+    "drop_subpaths",
     "horizontal_flip",
     "load_glyph",
     "merge_curves",

--- a/torchfont/transforms/functional/_subpath.py
+++ b/torchfont/transforms/functional/_subpath.py
@@ -43,6 +43,19 @@ def split_subpaths(inpt: Outline) -> tuple[Outline, ...]:
     )
 
 
+def drop_subpaths(
+    inpt: Outline,
+    drop_mask: Tensor,
+) -> Outline:
+    """Drop subpaths selected by an explicit boolean mask."""
+    return _native_outline(
+        inpt,
+        _ops.drop_subpaths,
+        drop_mask,
+        name="drop_subpaths",
+    )
+
+
 def normalize_subpath_start_points(inpt: Outline) -> Outline:
     """Choose a deterministic start point for each closed subpath.
 
@@ -79,6 +92,7 @@ def reorder_subpaths(inpt: Outline, keys: Tensor) -> Outline:
 
 
 __all__ = [
+    "drop_subpaths",
     "normalize_subpath_start_points",
     "reorder_subpaths",
     "set_subpath_start_points",


### PR DESCRIPTION
## Summary

- add `RandomSubpathDropout(p=0.5)` with independent per-subpath dropout
- add deterministic `functional.drop_subpaths(outline, drop_mask)` using an explicit boolean mask
- implement subpath filtering in Rust and register it as a PyTorch custom operator
- cover probability boundaries, reproducibility, shared parameters, validation, and `torch.compile`

## Validation

- `mise run check`
- `mise run build`
- `mise run test` (412 passed, 12 skipped)
- `mise run docs-build`
