### PR TITLE
Add outline geometry augmentations

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -74,7 +74,7 @@ inside an already-applied transform.
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
 | Subpaths | `SplitSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
-| Geometry | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
+| Geometry | `Affine`, `RandomAffine`, `RandomRotation`, `RandomScale`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `ElasticTransform`, `GaussianNoise` |
 | Output | `RenderBitmap` |
 
 `RenderBitmap` changes each `Outline` leaf into a plain `uint8` tensor. When
@@ -150,6 +150,9 @@ Gradient support varies by operation:
 | Kernel | Differentiable |
 | --- | --- |
 | `affine` | yes |
+| `scale` | yes |
+| `rotate` | yes |
+| `elastic` | yes, in both the outline and the displacement field |
 | `add_coordinate_noise` | yes, in both the outline and the noise |
 | `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
@@ -165,21 +168,22 @@ F.remove_overlaps(outline)
 # Raises RuntimeError
 ```
 
-`affine` and the flips pivot around the tight bounding-box centre. Gradients flow
+`affine`, `rotate`, `scale`, and the flips pivot around the tight bounding-box centre. Gradients flow
 through the transformed coordinates but not through that centre.
 
 ### Devices
 
-`LoadGlyph` returns CPU `float32` outlines. `Affine`, flip, curve, overlap, and
-subpath transforms, as well as `RenderBitmap`, require CPU `float32` outlines.
+`LoadGlyph` returns CPU `float32` outlines. `Affine`, `RandomAffine`,
+`RandomRotation`, `RandomScale`, flip, curve, overlap, and subpath transforms, as
+well as `RenderBitmap`, require CPU `float32` outlines.
 Convert other outlines explicitly before calling them:
 
 ```python
 outline = outline.to("cpu", torch.float32)
 ```
 
-`GaussianNoise` and `functional.add_coordinate_noise` preserve the input device and
-floating point dtype.
+`ElasticTransform`, `GaussianNoise`, `functional.elastic`, and
+`functional.add_coordinate_noise` preserve the input device and floating point dtype.
 
 ### `torch.compile`
 

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -73,7 +73,7 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
 | Subpath | `SplitSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
-| 幾何変換 | `Affine`, `RandomAffine`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `GaussianNoise` |
+| 幾何変換 | `Affine`, `RandomAffine`, `RandomRotation`, `RandomScale`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `ElasticTransform`, `GaussianNoise` |
 | 出力 | `RenderBitmap` |
 
 `RenderBitmap` は各 `Outline` を通常の `uint8` テンソルに変えます。これらが
@@ -147,6 +147,9 @@ Functional API は乱数を生成しません。ランダムな選択とパラ�
 | カーネル | 微分可能 |
 | --- | --- |
 | `affine` | はい |
+| `scale` | はい |
+| `rotate` | はい |
+| `elastic` | はい。Outline と変位場の両方について |
 | `add_coordinate_noise` | はい。Outline と Noise の両方について |
 | `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
@@ -162,21 +165,22 @@ F.remove_overlaps(outline)
 # RuntimeError が発生
 ```
 
-`affine` と Flip は Tight Bounding Box の中心を軸に変換します。勾配は変換後の
+`affine`、`rotate`、`scale` と Flip は Tight Bounding Box の中心を軸に変換します。勾配は変換後の
 座標を通って流れますが、この中心を通っては流れません。
 
 ### デバイス
 
-`LoadGlyph` は CPU の `float32` Outline を返します。`Affine`、Flip、Curve、Overlap、
-Subpath の各 Transform と `RenderBitmap` は、CPU の `float32` Outline を必要とします。
+`LoadGlyph` は CPU の `float32` Outline を返します。`Affine`、`RandomAffine`、
+`RandomRotation`、`RandomScale`、Flip、Curve、Overlap、Subpath の各 Transform と
+`RenderBitmap` は、CPU の `float32` Outline を必要とします。
 それ以外の Outline は呼び出す前に明示的に変換してください。
 
 ```python
 outline = outline.to("cpu", torch.float32)
 ```
 
-`GaussianNoise` と `functional.add_coordinate_noise` は入力の Device と浮動小数点 dtype を
-維持します。
+`ElasticTransform`、`GaussianNoise`、`functional.elastic`、
+`functional.add_coordinate_noise` は入力の Device と浮動小数点 dtype を維持します。
 
 ### `torch.compile`
 

--- a/tests/transforms/geometric/test_affine.py
+++ b/tests/transforms/geometric/test_affine.py
@@ -87,6 +87,37 @@ def test_affine_transforms_all_cubic_pairs(
     assert not torch.allclose(out[curve_idx, 4:6], coords[curve_idx, 4:6])
 
 
+def test_affine_supports_fixed_y_shear(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    _, out = affine(types, coords, shear=(0.0, 45.0))
+
+    line_idx = types.tolist().index(ElementType.LINE_TO.value)
+    assert out[line_idx, 4].item() == pytest.approx(coords[line_idx, 4].item())
+    assert out[line_idx, 5].item() == pytest.approx(
+        coords[line_idx, 5].item() + coords[line_idx, 4].item() - 0.5,
+        abs=1e-5,
+    )
+
+
+def test_affine_x_shear_is_applied_after_rotation(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    _, rotated = affine(types, coords, angle=30.0)
+    _, out = affine(types, coords, angle=30.0, shear=20.0)
+
+    line_idx = types.tolist().index(ElementType.LINE_TO.value)
+    center = torch.tensor([0.5, 0.5])
+    rotated_point = rotated[line_idx, 4:6]
+    expected_x = rotated_point[0] + torch.tan(torch.deg2rad(torch.tensor(20.0))) * (
+        rotated_point[1] - center[1]
+    )
+    assert out[line_idx, 4].item() == pytest.approx(expected_x.item(), abs=1e-5)
+    assert out[line_idx, 5].item() == pytest.approx(rotated_point[1].item(), abs=1e-5)
+
+
 def test_affine_quad_pair1_stays_zero(
     quad_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
@@ -126,8 +157,16 @@ def test_affine_rejects_non_finite_shear(
     shear: float,
 ) -> None:
     types, coords = simple_outline
-    with pytest.raises(ValueError, match="shear must be finite"):
+    with pytest.raises(ValueError, match="shear values must be finite"):
         affine(types, coords, shear=shear)
+
+
+def test_affine_rejects_non_finite_y_shear(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="shear values must be finite"):
+        affine(types, coords, shear=(0.0, float("nan")))
 
 
 @pytest.mark.parametrize(

--- a/tests/transforms/geometric/test_elastic_transform.py
+++ b/tests/transforms/geometric/test_elastic_transform.py
@@ -1,0 +1,99 @@
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from torchfont import Outline
+from torchfont.transforms import ElasticTransform
+from torchfont.transforms.functional import elastic
+
+
+def test_elastic_is_reproducible_with_torch_seed(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    torch.manual_seed(7)
+    first = ElasticTransform()(outline)
+    torch.manual_seed(7)
+    second = ElasticTransform()(outline)
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_elastic_shares_displacement_between_outlines(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    first, second = ElasticTransform()([outline, outline])
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_elastic_zero_alpha_is_identity(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    output = ElasticTransform(alpha=0.0)(outline)
+    assert torch.equal(output.coords, outline.coords)
+
+
+def test_elastic_constant_displacement_changes_only_active_coordinates(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    close_end_zeros: Callable[[torch.Tensor, torch.Tensor], bool],
+) -> None:
+    types, coords = simple_outline
+    displacement = torch.empty((1, 2, 2, 2))
+    displacement[..., 0] = 0.1
+    displacement[..., 1] = -0.2
+
+    output = elastic(Outline(types, coords), displacement)
+
+    assert torch.allclose(
+        output.coords[0, 4:6], coords[0, 4:6] + torch.tensor([0.1, -0.2])
+    )
+    assert close_end_zeros(types, output.coords)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("alpha", -0.1),
+        ("alpha", (0.1, float("nan"))),
+        ("sigma", -0.1),
+        ("sigma", (float("inf"), 0.1)),
+    ],
+)
+def test_elastic_rejects_invalid_parameters(
+    name: str, value: float | tuple[float, float]
+) -> None:
+    with pytest.raises(ValueError, match=f"{name} values"):
+        ElasticTransform(**{name: value})
+
+
+@pytest.mark.parametrize("shape", [(2, 4, 4, 2), (1, 4, 4, 3), (1, 1, 4, 2)])
+def test_elastic_rejects_incompatible_displacement_shape(
+    simple_outline: tuple[torch.Tensor, torch.Tensor], shape: tuple[int, ...]
+) -> None:
+    with pytest.raises(ValueError, match="displacement must have shape"):
+        elastic(Outline(*simple_outline), torch.zeros(shape))
+
+
+def test_elastic_is_differentiable(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    coords = coords.requires_grad_()
+    displacement = torch.rand((1, 4, 4, 2), requires_grad=True)
+
+    elastic(Outline(types, coords), displacement).coords.sum().backward()
+
+    assert coords.grad is not None
+    assert displacement.grad is not None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_elastic_preserves_cuda_device(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*(tensor.cuda() for tensor in simple_outline))
+    output = ElasticTransform()(outline)
+    assert output.types.device.type == "cuda"
+    assert output.coords.device.type == "cuda"

--- a/tests/transforms/geometric/test_random_affine.py
+++ b/tests/transforms/geometric/test_random_affine.py
@@ -32,6 +32,24 @@ def test_random_affine_preserves_padding_and_shares_parameters(
     assert close_end_zeros(first.types, first.coords)
 
 
+def test_random_affine_samples_x_and_y_shear_ranges() -> None:
+    transform = RandomAffine(shear=(-20.0, -10.0, 10.0, 20.0))
+
+    shear_x, shear_y = transform.make_params([])["shear"]
+
+    assert -20.0 <= shear_x <= -10.0
+    assert 10.0 <= shear_y <= 20.0
+
+
+def test_random_affine_two_value_shear_only_samples_x() -> None:
+    transform = RandomAffine(shear=(-20.0, -10.0))
+
+    shear_x, shear_y = transform.make_params([])["shear"]
+
+    assert -20.0 <= shear_x <= -10.0
+    assert shear_y == 0.0
+
+
 @pytest.mark.parametrize(
     "scale",
     [(-1.0, 1.0), (float("nan"), 1.0), (1.0, float("inf")), (2.0, 1.0)],
@@ -52,10 +70,26 @@ def test_random_affine_rejects_invalid_degrees(
         RandomAffine(degrees=degrees)
 
 
-@pytest.mark.parametrize("name", ["degrees", "translate", "scale", "shear"])
+@pytest.mark.parametrize("name", ["degrees", "translate", "scale"])
 def test_random_affine_rejects_non_pair_ranges(name: str) -> None:
     with pytest.raises(ValueError, match="too many values to unpack"):
         RandomAffine(**{name: (1.0, 2.0, 3.0)})  # ty: ignore[invalid-argument-type]
+
+
+def test_random_affine_rejects_invalid_shear_length() -> None:
+    with pytest.raises(ValueError, match="two or four values"):
+        RandomAffine(shear=(1.0, 2.0, 3.0))  # ty: ignore[invalid-argument-type]
+
+
+@pytest.mark.parametrize(
+    "shear",
+    [(0.0, float("nan"), 0.0, 1.0), (0.0, 1.0, 2.0, float("inf"))],
+)
+def test_random_affine_rejects_invalid_four_value_shear(
+    shear: tuple[float, float, float, float],
+) -> None:
+    with pytest.raises(ValueError, match="range values must be finite and ordered"):
+        RandomAffine(shear=shear)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")

--- a/tests/transforms/geometric/test_random_rotation.py
+++ b/tests/transforms/geometric/test_random_rotation.py
@@ -1,0 +1,67 @@
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from torchfont import Outline
+from torchfont.transforms import RandomRotation
+from torchfont.transforms import functional as F  # noqa: N812
+
+
+def test_rotate_matches_affine(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    assert torch.equal(
+        F.rotate(outline, 15.0).coords, F.affine(outline, angle=15.0).coords
+    )
+
+
+def test_random_rotation_is_reproducible_with_torch_seed(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    torch.manual_seed(7)
+    first = RandomRotation(30.0)(outline)
+    torch.manual_seed(7)
+    second = RandomRotation(30.0)(outline)
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_random_rotation_shares_angle_between_outlines(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    close_end_zeros: Callable[[torch.Tensor, torch.Tensor], bool],
+) -> None:
+    outline = Outline(*simple_outline)
+    first, second = RandomRotation((-10.0, 20.0))([outline, outline])
+    assert torch.equal(first.coords, second.coords)
+    assert close_end_zeros(first.types, first.coords)
+
+
+def test_random_rotation_samples_requested_range() -> None:
+    transform = RandomRotation((10.0, 20.0))
+
+    angle = transform.make_params([])["angle"]
+
+    assert 10.0 <= angle <= 20.0
+
+
+def test_random_rotation_number_creates_symmetric_range() -> None:
+    assert RandomRotation(15.0).degrees == (-15.0, 15.0)
+
+
+@pytest.mark.parametrize("degrees", [float("nan"), (0.0, float("inf")), (10.0, -10.0)])
+def test_random_rotation_rejects_invalid_degrees(
+    degrees: float | tuple[float, float],
+) -> None:
+    with pytest.raises(ValueError, match="range values must be finite and ordered"):
+        RandomRotation(degrees)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_rotation_rejects_cuda_input(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*(tensor.cuda() for tensor in simple_outline))
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        RandomRotation(10.0)(outline)

--- a/tests/transforms/geometric/test_random_scale.py
+++ b/tests/transforms/geometric/test_random_scale.py
@@ -1,0 +1,89 @@
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from torchfont import ElementType, Outline
+from torchfont.transforms import RandomScale
+from torchfont.transforms.functional import scale
+
+
+def test_scale_applies_independent_factors(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    output = scale(Outline(types, coords), (2.0, 0.5))
+
+    line_idx = types.tolist().index(ElementType.LINE_TO.value)
+    assert output.coords[line_idx, 4].item() == pytest.approx(
+        coords[line_idx, 4].item() * 2.0 - 0.5
+    )
+    assert output.coords[line_idx, 5].item() == pytest.approx(
+        coords[line_idx, 5].item() * 0.5 + 0.25
+    )
+
+
+def test_random_scale_is_reproducible_with_torch_seed(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    transform = RandomScale(scale_x=(0.8, 1.2), scale_y=(0.9, 1.1))
+    torch.manual_seed(7)
+    first = transform(outline)
+    torch.manual_seed(7)
+    second = transform(outline)
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_random_scale_shares_factors_between_outlines(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    close_end_zeros: Callable[[torch.Tensor, torch.Tensor], bool],
+) -> None:
+    outline = Outline(*simple_outline)
+    first, second = RandomScale(scale_x=(0.8, 1.2), scale_y=(0.9, 1.1))(
+        [outline, outline]
+    )
+    assert torch.equal(first.coords, second.coords)
+    assert close_end_zeros(first.types, first.coords)
+
+
+def test_random_scale_defaults_to_identity(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*simple_outline)
+    output = RandomScale()(outline)
+    assert torch.equal(output.coords, outline.coords)
+
+
+def test_random_scale_samples_requested_ranges() -> None:
+    transform = RandomScale(scale_x=(0.8, 0.9), scale_y=(1.1, 1.2))
+
+    scale_x, scale_y = transform.make_params([])["factors"]
+
+    assert 0.8 <= scale_x <= 0.9
+    assert 1.1 <= scale_y <= 1.2
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("scale_x", (0.0, 1.0), "positive and finite"),
+        ("scale_x", (1.0, float("nan")), "positive and finite"),
+        ("scale_y", (1.0, float("inf")), "positive and finite"),
+        ("scale_y", (1.2, 0.8), "ordered"),
+    ],
+)
+def test_random_scale_rejects_invalid_ranges(
+    name: str, value: tuple[float, float], message: str
+) -> None:
+    with pytest.raises(ValueError, match=f"{name} values must be {message}"):
+        RandomScale(**{name: value})
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_scale_rejects_cuda_input(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    outline = Outline(*(tensor.cuda() for tensor in simple_outline))
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        RandomScale(scale_x=(0.8, 1.2))(outline)

--- a/tests/transforms/test_autograd.py
+++ b/tests/transforms/test_autograd.py
@@ -70,6 +70,22 @@ def test_add_coordinate_noise_is_differentiable_in_both_arguments() -> None:
     assert noise.grad is not None
 
 
+def test_scale_is_differentiable() -> None:
+    outline, coords = _grad_outline()
+
+    F.scale(outline, (0.9, 1.1)).coords.sum().backward()
+
+    assert coords.grad is not None
+
+
+def test_rotate_is_differentiable() -> None:
+    outline, coords = _grad_outline()
+
+    F.rotate(outline, 10.0).coords.sum().backward()
+
+    assert coords.grad is not None
+
+
 def test_flip_without_winding_preservation_is_differentiable() -> None:
     outline, coords = _grad_outline()
 

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -41,6 +41,9 @@ def _pipeline(types: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
     outline = F.cubic_to_quad(outline)
     outline = F.merge_curves(outline)
     outline = F.affine(outline, angle=10.0, scale=1.1)
+    outline = F.rotate(outline, 5.0)
+    outline = F.scale(outline, (0.9, 1.1))
+    outline = F.elastic(outline, coords.new_zeros((1, 4, 4, 2)))
     outline = F.normalize_subpath_start_points(outline)
     return F.render_bitmap(outline, 32)
 

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -11,10 +11,13 @@ from torchfont.transforms._curves import (
 )
 from torchfont.transforms._geometry import (
     Affine,
+    ElasticTransform,
     GaussianNoise,
     HorizontalFlip,
     RandomAffine,
     RandomHorizontalFlip,
+    RandomRotation,
+    RandomScale,
     RandomVerticalFlip,
     VerticalFlip,
 )
@@ -33,6 +36,7 @@ __all__ = [
     "Affine",
     "Compose",
     "CubicToQuad",
+    "ElasticTransform",
     "GaussianNoise",
     "HorizontalFlip",
     "LoadGlyph",
@@ -43,6 +47,8 @@ __all__ = [
     "RandomApply",
     "RandomHorizontalFlip",
     "RandomRemoveOverlaps",
+    "RandomRotation",
+    "RandomScale",
     "RandomSplitSegments",
     "RandomSubpathDropout",
     "RandomSubpathOrder",

--- a/torchfont/transforms/_geometry.py
+++ b/torchfont/transforms/_geometry.py
@@ -6,9 +6,13 @@ import math
 from typing import TYPE_CHECKING, Any
 
 import torch
+from torch.nn import functional as nn_functional
 
 from torchfont.transforms import functional as _functional
 from torchfont.transforms._transform import Transform
+
+_SHEAR_RANGE_SIZE = 2
+_XY_SHEAR_RANGE_SIZE = 4
 
 if TYPE_CHECKING:
     from torchfont._outline import Outline
@@ -81,7 +85,7 @@ class Affine(Transform):
         angle: float = 0.0,
         translate: tuple[float, float] = (0.0, 0.0),
         scale: float = 1.0,
-        shear: float = 0.0,
+        shear: float | tuple[float, float] = 0.0,
     ) -> None:
         super().__init__()
         self.angle = angle
@@ -121,7 +125,7 @@ class RandomAffine(Transform):
         degrees: float | tuple[float, float] = 0.0,
         translate: tuple[float, float] | None = None,
         scale: tuple[float, float] | None = None,
-        shear: float | tuple[float, float] = 0.0,
+        shear: float | tuple[float, float] | tuple[float, float, float, float] = 0.0,
     ) -> None:
         super().__init__()
         self.degrees = _symmetric_range(degrees)
@@ -142,10 +146,16 @@ class RandomAffine(Transform):
                 raise ValueError(msg)
         self.translate = translate
         self.scale = scale
-        self.shear = _symmetric_range(shear)
+        if isinstance(shear, (float, int)) or len(shear) == _SHEAR_RANGE_SIZE:
+            self.shear = _symmetric_range(shear)
+        elif len(shear) == _XY_SHEAR_RANGE_SIZE:
+            self.shear = (*_symmetric_range(shear[:2]), *_symmetric_range(shear[2:]))
+        else:
+            msg = "shear must be a number or a sequence of two or four values"
+            raise ValueError(msg)
 
     def make_params(self, _flat_inputs: list[Any]) -> dict[str, Any]:
-        values = torch.rand(5)
+        values = torch.rand(6)
 
         def uniform(bounds: tuple[float, float], index: int) -> float:
             return bounds[0] + (bounds[1] - bounds[0]) * values[index].item()
@@ -158,11 +168,70 @@ class RandomAffine(Transform):
                 uniform((-translate[1], translate[1]), 2),
             ),
             "scale": uniform(self.scale, 3) if self.scale is not None else 1.0,
-            "shear": uniform(self.shear, 4),
+            "shear": (
+                uniform(self.shear[:2], 4),
+                uniform(self.shear[2:], 5)
+                if len(self.shear) == _XY_SHEAR_RANGE_SIZE
+                else 0.0,
+            ),
         }
 
     def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
         return _functional.affine(inpt, **params)
+
+
+class RandomRotation(Transform):
+    """Rotate outlines by a randomly sampled angle."""
+
+    def __init__(self, degrees: float | tuple[float, float]) -> None:
+        super().__init__()
+        self.degrees = _symmetric_range(degrees)
+
+    def make_params(self, _flat_inputs: list[Any]) -> dict[str, Any]:
+        value = torch.rand(()).item()
+        lower, upper = self.degrees
+        return {"angle": lower + (upper - lower) * value}
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        return _functional.rotate(inpt, params["angle"])
+
+
+def _positive_range(value: tuple[float, float], name: str) -> tuple[float, float]:
+    lower, upper = value
+    bounds = (float(lower), float(upper))
+    if not all(math.isfinite(item) and item > 0.0 for item in bounds):
+        msg = f"{name} values must be positive and finite"
+        raise ValueError(msg)
+    if bounds[0] > bounds[1]:
+        msg = f"{name} values must be ordered"
+        raise ValueError(msg)
+    return bounds
+
+
+class RandomScale(Transform):
+    """Scale outlines independently along the x and y axes."""
+
+    def __init__(
+        self,
+        scale_x: tuple[float, float] = (1.0, 1.0),
+        scale_y: tuple[float, float] = (1.0, 1.0),
+    ) -> None:
+        super().__init__()
+        self.scale_x = _positive_range(scale_x, "scale_x")
+        self.scale_y = _positive_range(scale_y, "scale_y")
+
+    def make_params(self, _flat_inputs: list[Any]) -> dict[str, Any]:
+        values = torch.rand(2)
+
+        def uniform(bounds: tuple[float, float], index: int) -> float:
+            return bounds[0] + (bounds[1] - bounds[0]) * values[index].item()
+
+        return {
+            "factors": (uniform(self.scale_x, 0), uniform(self.scale_y, 1)),
+        }
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        return _functional.scale(inpt, params["factors"])
 
 
 class GaussianNoise(Transform):
@@ -183,12 +252,78 @@ class GaussianNoise(Transform):
         return _functional.add_coordinate_noise(inpt, params["noise"])
 
 
+def _pair(value: float | tuple[float, float], name: str) -> tuple[float, float]:
+    if isinstance(value, (float, int)):
+        pair = (float(value), float(value))
+    else:
+        first, second = value
+        pair = (float(first), float(second))
+    if not all(math.isfinite(item) and item >= 0.0 for item in pair):
+        msg = f"{name} values must be non-negative and finite"
+        raise ValueError(msg)
+    return pair
+
+
+class ElasticTransform(Transform):
+    """Transform outlines with a smooth random displacement field.
+
+    ``alpha`` controls displacement magnitude and ``sigma`` controls
+    smoothness. Both are measured in em units and may be specified separately
+    for the x and y axes.
+    """
+
+    _GRID_SIZE = 64
+    _CANVAS_SIZE = 1.5
+
+    def __init__(
+        self,
+        alpha: float | tuple[float, float] = 0.05,
+        sigma: float | tuple[float, float] = 0.1,
+    ) -> None:
+        super().__init__()
+        self.alpha = _pair(alpha, "alpha")
+        self.sigma = _pair(sigma, "sigma")
+
+    @classmethod
+    def _smooth(cls, noise: torch.Tensor, sigma: float) -> torch.Tensor:
+        if sigma == 0.0:
+            return noise
+        sigma_pixels = sigma * (cls._GRID_SIZE - 1) / cls._CANVAS_SIZE
+        kernel_size = int(8.0 * sigma_pixels + 1.0)
+        if kernel_size % 2 == 0:
+            kernel_size += 1
+        radius = kernel_size // 2
+        positions = torch.arange(-radius, radius + 1, dtype=noise.dtype)
+        kernel = torch.exp(-(positions**2) / (2.0 * sigma_pixels**2))
+        kernel /= kernel.sum()
+        noise = nn_functional.conv2d(
+            noise, kernel.reshape(1, 1, 1, -1), padding=(0, radius)
+        )
+        return nn_functional.conv2d(
+            noise, kernel.reshape(1, 1, -1, 1), padding=(radius, 0)
+        )
+
+    def make_params(self, _flat_inputs: list[Any]) -> dict[str, Any]:
+        fields = []
+        for alpha, sigma in zip(self.alpha, self.sigma, strict=True):
+            noise = torch.rand(1, 1, self._GRID_SIZE, self._GRID_SIZE) * 2.0 - 1.0
+            fields.append(self._smooth(noise, sigma) * alpha)
+        displacement = torch.cat(fields, dim=1).permute(0, 2, 3, 1)
+        return {"displacement": displacement}
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        return _functional.elastic(inpt, params["displacement"])
+
+
 __all__ = [
     "Affine",
+    "ElasticTransform",
     "GaussianNoise",
     "HorizontalFlip",
     "RandomAffine",
     "RandomHorizontalFlip",
+    "RandomRotation",
+    "RandomScale",
     "RandomVerticalFlip",
     "VerticalFlip",
 ]

--- a/torchfont/transforms/functional/__init__.py
+++ b/torchfont/transforms/functional/__init__.py
@@ -10,7 +10,10 @@ from torchfont.transforms.functional._curves import (
 from torchfont.transforms.functional._geometry import (
     add_coordinate_noise,
     affine,
+    elastic,
     horizontal_flip,
+    rotate,
+    scale,
     vertical_flip,
 )
 from torchfont.transforms.functional._glyph import load_glyph
@@ -31,6 +34,7 @@ __all__ = [
     "affine",
     "cubic_to_quad",
     "drop_subpaths",
+    "elastic",
     "horizontal_flip",
     "load_glyph",
     "merge_curves",
@@ -40,6 +44,8 @@ __all__ = [
     "remove_overlaps",
     "render_bitmap",
     "reorder_subpaths",
+    "rotate",
+    "scale",
     "set_subpath_start_points",
     "split_segments",
     "split_subpaths",

--- a/torchfont/transforms/functional/_geometry.py
+++ b/torchfont/transforms/functional/_geometry.py
@@ -21,6 +21,7 @@ import math
 
 import torch
 from torch import Tensor
+from torch.nn import functional as nn_functional
 
 from torchfont import _ops
 from torchfont._outline import ElementType, Outline
@@ -95,18 +96,25 @@ def _apply_matrix(
 def _rotation_scale_shear_matrix(
     angle_deg: float,
     scale: float,
-    shear_deg: float,
+    shear_deg: float | tuple[float, float],
     *,
     like: Tensor,
 ) -> Tensor:
-    """Return a 2x2 matrix for scale * x-shear * rotation (all applied in place)."""
+    """Return a 2x2 matrix for scale, x/y shear, and rotation."""
     a = math.radians(angle_deg)
-    s = math.radians(shear_deg)
-    cos_a, sin_a, tan_s = math.cos(a), math.sin(a), math.tan(s)
+    if isinstance(shear_deg, tuple):
+        shear_x, shear_y = shear_deg
+    else:
+        shear_x, shear_y = shear_deg, 0.0
+    sx, sy = math.radians(shear_x), math.radians(shear_y)
+    cos_a, sin_a = math.cos(a), math.sin(a)
+    tan_x, tan_y = math.tan(sx), math.tan(sy)
+    x0 = cos_a + tan_x * sin_a
+    x1 = -sin_a + tan_x * cos_a
     return like.new_tensor(
         [
-            [scale * (cos_a + sin_a * tan_s), scale * (-sin_a + cos_a * tan_s)],
-            [scale * sin_a, scale * cos_a],
+            [scale * x0, scale * x1],
+            [scale * (tan_y * x0 + sin_a), scale * (tan_y * x1 + cos_a)],
         ],
     )
 
@@ -184,7 +192,7 @@ def _affine(
     angle: float = 0.0,
     translate: tuple[float, float] = (0.0, 0.0),
     scale: float = 1.0,
-    shear: float = 0.0,
+    shear: float | tuple[float, float] = 0.0,
 ) -> tuple[Tensor, Tensor]:
     """Apply a deterministic affine transformation to a glyph outline.
 
@@ -200,7 +208,7 @@ def _affine(
         translate: Translation ``(tx, ty)`` in em units applied
             after rotation and scaling. Values must be finite.
         scale: Uniform scale factor (must be positive and finite).
-        shear: x-shear angle in degrees.
+        shear: x-shear angle in degrees, or fixed ``(x, y)`` shear angles.
 
     Returns:
         A new ``(types, coords)`` pair with the affine transform applied.
@@ -213,8 +221,9 @@ def _affine(
     if _is_nan(angle) or _is_infinite(angle):
         msg = "angle must be finite"
         raise ValueError(msg)
-    if _is_nan(shear) or _is_infinite(shear):
-        msg = "shear must be finite"
+    shear_values = shear if isinstance(shear, tuple) else (shear,)
+    if any(_is_nan(value) or _is_infinite(value) for value in shear_values):
+        msg = "shear values must be finite"
         raise ValueError(msg)
     if any(_is_nan(value) or _is_infinite(value) for value in translate):
         msg = "translate values must be finite"
@@ -258,7 +267,7 @@ def affine(
     angle: float = 0.0,
     translate: tuple[float, float] = (0.0, 0.0),
     scale: float = 1.0,
-    shear: float = 0.0,
+    shear: float | tuple[float, float] = 0.0,
 ) -> Outline:
     """Apply a deterministic affine transformation.
 
@@ -276,6 +285,30 @@ def affine(
             shear=shear,
         )[1],
     )
+
+
+def scale(inpt: Outline, factors: tuple[float, float]) -> Outline:
+    """Scale an outline independently on the x and y axes.
+
+    The transform pivots around the tight bounding-box centre and is
+    differentiable with respect to ``coords``. ``factors`` contains the fixed
+    ``(scale_x, scale_y)`` multipliers.
+    """
+    scale_x, scale_y = factors
+    if any(_is_nan(value) or _is_infinite(value) or value <= 0.0 for value in factors):
+        msg = "scale factors must be positive and finite"
+        raise ValueError(msg)
+    matrix = inpt.coords.new_tensor([[scale_x, 0.0], [0.0, scale_y]])
+    center = _bbox_center(inpt.types, inpt.coords)
+    return _same_types(
+        inpt,
+        _apply_matrix(inpt.types, inpt.coords, matrix, center, (0.0, 0.0)),
+    )
+
+
+def rotate(inpt: Outline, angle: float) -> Outline:
+    """Rotate an outline counter-clockwise around its tight bounding-box centre."""
+    return affine(inpt, angle=angle)
 
 
 def add_coordinate_noise(inpt: Outline, noise: Tensor) -> Outline:
@@ -302,4 +335,61 @@ def add_coordinate_noise(inpt: Outline, noise: Tensor) -> Outline:
     )
 
 
-__all__ = ["add_coordinate_noise", "affine", "horizontal_flip", "vertical_flip"]
+def elastic(inpt: Outline, displacement: Tensor) -> Outline:
+    """Apply a dense displacement field to an outline.
+
+    ``displacement`` has shape ``(1, H, W, 2)`` and stores x/y offsets in em
+    units over the standard TorchFont canvas ``[-0.25, 1.25]``. Values between
+    grid points are bilinearly interpolated. The operation is differentiable
+    with respect to both the outline coordinates and the displacement field.
+    """
+    expected_ndim = 4
+    coordinate_dim = 2
+    minimum_grid_size = 2
+    if (
+        displacement.ndim != expected_ndim
+        or displacement.shape[0] != 1
+        or displacement.shape[-1] != coordinate_dim
+        or displacement.shape[1] < minimum_grid_size
+        or displacement.shape[2] < minimum_grid_size
+    ):
+        msg = (
+            "displacement must have shape (1, H, W, 2) with H and W at least 2, "
+            f"got {tuple(displacement.shape)}"
+        )
+        raise ValueError(msg)
+
+    types, coords = inpt.types, inpt.coords
+    points = coords.reshape(-1, 3, 2)
+    # grid_sample expects coordinates in [-1, 1]. TorchFont's full em canvas
+    # runs from -0.25 to 1.25, so this is the corresponding affine map.
+    sample_grid = ((points + 0.25) * (2.0 / 1.5) - 1.0).reshape(1, -1, 1, 2)
+    field = displacement.permute(0, 3, 1, 2).to(
+        device=coords.device, dtype=coords.dtype
+    )
+    offsets = (
+        nn_functional.grid_sample(
+            field,
+            sample_grid,
+            mode="bilinear",
+            padding_mode="border",
+            align_corners=True,
+        )
+        .reshape(2, -1)
+        .T.reshape_as(points)
+    )
+    active = torch.stack(_active_pairs(types), dim=1).unsqueeze(-1)
+    return _same_types(
+        inpt, torch.where(active, points + offsets, points).reshape_as(coords)
+    )
+
+
+__all__ = [
+    "add_coordinate_noise",
+    "affine",
+    "elastic",
+    "horizontal_flip",
+    "rotate",
+    "scale",
+    "vertical_flip",
+]


### PR DESCRIPTION
## Summary

- add TorchVision-style `ElasticTransform` and `RandomRotation`
- add independent-axis `RandomScale` with deterministic `scale` and `rotate` functionals
- support independent x/y shear ranges in `RandomAffine`
- document the public surface, differentiability, and device behavior in English and Japanese

## Validation

- `mise run format`
- `mise run check`
- `mise run test` (450 passed, 15 skipped)
- `mise run docs-build`
