### PR TITLE
Add subpath truncation transforms

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -73,7 +73,7 @@ inside an already-applied transform.
 | Containers | `Compose`, `RandomApply` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpaths | `SplitSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpaths | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | Geometry | `Affine`, `RandomAffine`, `RandomRotation`, `RandomScale`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `ElasticTransform`, `GaussianNoise` |
 | Output | `RenderBitmap` |
 
@@ -157,7 +157,7 @@ Gradient support varies by operation:
 | `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
 | `remove_overlaps`, `remove_overlap_groups` | no |
-| `split_subpaths`, `drop_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
+| `split_subpaths`, `truncate_subpaths`, `drop_subpaths`, `drop_subpaths_to_fit`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
 | `render_bitmap` | no |
 
 Passing an outline that requires grad to an operation marked "no" raises:

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -72,7 +72,7 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | コンテナ | `Compose`, `RandomApply` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpath | `SplitSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpath | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | 幾何変換 | `Affine`, `RandomAffine`, `RandomRotation`, `RandomScale`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `ElasticTransform`, `GaussianNoise` |
 | 出力 | `RenderBitmap` |
 
@@ -154,7 +154,7 @@ Functional API は乱数を生成しません。ランダムな選択とパラ�
 | `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
 | `remove_overlaps`, `remove_overlap_groups` | いいえ |
-| `split_subpaths`, `drop_subpaths`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
+| `split_subpaths`, `truncate_subpaths`, `drop_subpaths`, `drop_subpaths_to_fit`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
 | `render_bitmap` | いいえ |
 
 「いいえ」の処理に勾配を要求する Outline を渡すとエラーになります。

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -71,6 +71,68 @@ pub(crate) fn drop_subpaths<'py>(
 }
 
 #[pyfunction]
+pub(crate) fn truncate_subpaths<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+    max_length: Option<usize>,
+    max_subpaths: Option<usize>,
+) -> PyResult<OutlineArrays<'py>> {
+    if max_length == Some(0) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "max_length must be positive",
+        ));
+    }
+    if max_length.is_none() && max_subpaths.is_none() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "max_length or max_subpaths must be specified",
+        ));
+    }
+    let outline = decode(types.as_slice()?, coords.as_slice()?)?;
+    let result = py.detach(|| subpath::truncate_subpaths(&outline, max_length, max_subpaths));
+    Ok(encode(py, &result))
+}
+
+#[pyfunction]
+pub(crate) fn drop_subpaths_to_fit<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+    removal_values: PyReadonlyArray1<'_, f32>,
+    max_length: Option<usize>,
+    max_subpaths: Option<usize>,
+) -> PyResult<OutlineArrays<'py>> {
+    use crate::outline::ElementType;
+    if max_length == Some(0) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "max_length must be positive",
+        ));
+    }
+    if max_length.is_none() && max_subpaths.is_none() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "max_length or max_subpaths must be specified",
+        ));
+    }
+    let types = types.as_slice()?;
+    let values = removal_values.as_slice()?;
+    let outline = decode(types, coords.as_slice()?)?;
+    if values.len() < types.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "removal_values length must be at least types length",
+        ));
+    }
+    let subpath_values: Vec<_> = types
+        .iter()
+        .zip(values)
+        .filter_map(|(&ty, &value)| (ty == ElementType::MoveTo as i64).then_some(value))
+        .collect();
+    let result = py.detach(|| {
+        subpath::drop_subpaths_to_fit(&outline, &subpath_values, max_length, max_subpaths)
+    });
+    Ok(encode(py, &result))
+}
+
+#[pyfunction]
 pub(crate) fn quad_to_cubic<'py>(
     py: Python<'py>,
     types: PyReadonlyArray1<'_, i64>,
@@ -352,6 +414,8 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(random_split_segments, m)?)?;
     m.add_function(wrap_pyfunction!(split_subpaths, m)?)?;
     m.add_function(wrap_pyfunction!(drop_subpaths, m)?)?;
+    m.add_function(wrap_pyfunction!(truncate_subpaths, m)?)?;
+    m.add_function(wrap_pyfunction!(drop_subpaths_to_fit, m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(random_remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -26,6 +26,54 @@ pub(crate) fn drop_subpaths(outline: &BezPath, drop_mask: &[bool]) -> BezPath {
     result
 }
 
+pub(crate) fn truncate_subpaths(
+    outline: &BezPath,
+    max_length: Option<usize>,
+    max_subpaths: Option<usize>,
+) -> BezPath {
+    let mut result = BezPath::new();
+    let mut remaining = max_length.map(|length| length - 1);
+    for (index, subpath) in outline.subpaths().enumerate() {
+        if max_subpaths.is_some_and(|count| index >= count)
+            || remaining.is_some_and(|length| subpath.len() > length)
+        {
+            break;
+        }
+        result.extend(subpath.iter().copied());
+        if let Some(length) = &mut remaining {
+            *length -= subpath.len();
+        }
+    }
+    result
+}
+
+pub(crate) fn drop_subpaths_to_fit(
+    outline: &BezPath,
+    removal_values: &[f32],
+    max_length: Option<usize>,
+    max_subpaths: Option<usize>,
+) -> BezPath {
+    let subpaths: Vec<_> = outline.subpaths().collect();
+    let mut element_count = subpaths.iter().map(|subpath| subpath.len()).sum::<usize>() + 1;
+    let mut subpath_count = subpaths.len();
+    let mut removal_order: Vec<_> = removal_values.iter().copied().enumerate().collect();
+    removal_order.sort_by(|(a_idx, a), (b_idx, b)| a.total_cmp(b).then_with(|| a_idx.cmp(b_idx)));
+    let mut drop_mask = vec![false; subpath_count];
+
+    for (index, _) in removal_order {
+        let exceeds_length = max_length.is_some_and(|limit| element_count > limit);
+        let exceeds_count = max_subpaths.is_some_and(|limit| subpath_count > limit);
+        if !exceeds_length && !exceeds_count {
+            break;
+        }
+        drop_mask[index] = true;
+        element_count -= subpaths[index].len();
+        subpath_count -= 1;
+    }
+
+    drop_subpaths(outline, &drop_mask)
+}
+
 pub(crate) fn normalize_subpath_start_points(outline: &BezPath) -> BezPath {
     transform_start_points(outline, |subpath, _| {
         nodes(subpath)
@@ -170,6 +218,63 @@ mod tests {
 
         assert_eq!(drop_subpaths(&outline, &[false, true]), first);
         assert!(drop_subpaths(&outline, &[true, true]).is_empty());
+    }
+
+    #[test]
+    fn truncates_at_subpath_boundaries() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(2.0, 0.0), vec![line(3.0, 0.0)]);
+        let outline = outline_from_subpaths([first.clone(), second]);
+
+        assert_eq!(truncate_subpaths(&outline, Some(4), None), first);
+    }
+
+    #[test]
+    fn truncation_keeps_every_fitting_subpath() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(2.0, 0.0), vec![line(3.0, 0.0)]);
+        let outline = outline_from_subpaths([first, second]);
+
+        assert_eq!(truncate_subpaths(&outline, Some(6), None), outline);
+    }
+
+    #[test]
+    fn truncation_can_return_an_empty_path() {
+        let outline = outline_from_subpaths([open(pt(0.0, 0.0), vec![line(1.0, 0.0)])]);
+
+        assert!(truncate_subpaths(&outline, Some(1), None).is_empty());
+    }
+
+    #[test]
+    fn truncates_by_subpath_count() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(2.0, 0.0), vec![line(3.0, 0.0)]);
+        let outline = outline_from_subpaths([first.clone(), second]);
+
+        assert_eq!(truncate_subpaths(&outline, None, Some(1)), first);
+        assert!(truncate_subpaths(&outline, None, Some(0)).is_empty());
+    }
+
+    #[test]
+    fn drops_randomly_ordered_subpaths_until_limits_fit() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(2.0, 0.0), vec![line(3.0, 0.0)]);
+        let outline = outline_from_subpaths([first, second.clone()]);
+
+        assert_eq!(
+            drop_subpaths_to_fit(&outline, &[0.1, 0.9], None, Some(1)),
+            second
+        );
+    }
+
+    #[test]
+    fn random_truncation_preserves_an_outline_that_fits() {
+        let outline = outline_from_subpaths([open(pt(0.0, 0.0), vec![line(1.0, 0.0)])]);
+
+        assert_eq!(
+            drop_subpaths_to_fit(&outline, &[0.1], Some(3), Some(1)),
+            outline
+        );
     }
 
     #[test]

--- a/tests/transforms/subpath/test_random_truncate_subpaths.py
+++ b/tests/transforms/subpath/test_random_truncate_subpaths.py
@@ -1,0 +1,87 @@
+import pytest
+import torch
+
+from torchfont import ElementType, Outline
+from torchfont.transforms import RandomTruncateSubpaths, functional
+
+
+@pytest.fixture
+def three_lines() -> Outline:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.END,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(7, 6)
+    coords[:, 4] = torch.arange(7)
+    return Outline(types, coords)
+
+
+def test_drop_subpaths_to_fit_uses_explicit_removal_order(
+    three_lines: Outline,
+) -> None:
+    output = functional.drop_subpaths_to_fit(
+        three_lines,
+        torch.tensor([0.1, 0.0, 0.9, 0.0, 0.2, 0.0, 0.0]),
+        max_subpaths=2,
+    )
+
+    assert output.coords[output.types == ElementType.MOVE_TO, 4].tolist() == [
+        2.0,
+        4.0,
+    ]
+
+
+def test_random_truncate_subpaths_meets_both_limits(three_lines: Outline) -> None:
+    output = RandomTruncateSubpaths(max_length=3, max_subpaths=2)(three_lines)
+
+    assert len(output) <= 3
+    assert output.types.tolist().count(ElementType.MOVE_TO) <= 2
+
+
+def test_random_truncate_subpaths_zero_count_returns_empty(
+    three_lines: Outline,
+) -> None:
+    output = RandomTruncateSubpaths(max_subpaths=0)(three_lines)
+
+    assert output.types.tolist() == [ElementType.END]
+
+
+def test_random_truncate_subpaths_is_reproducible(three_lines: Outline) -> None:
+    torch.manual_seed(0)
+    first = RandomTruncateSubpaths(max_subpaths=1)(three_lines)
+    torch.manual_seed(0)
+    second = RandomTruncateSubpaths(max_subpaths=1)(three_lines)
+
+    assert torch.equal(first.types, second.types)
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_random_truncate_subpaths_shares_removal_order_between_outlines(
+    three_lines: Outline,
+) -> None:
+    first, second = RandomTruncateSubpaths(max_subpaths=1)([three_lines, three_lines])
+
+    assert torch.equal(first.types, second.types)
+    assert torch.equal(first.coords, second.coords)
+
+
+def test_random_truncate_subpaths_requires_a_limit() -> None:
+    with pytest.raises(
+        ValueError, match="max_length or max_subpaths must be specified"
+    ):
+        RandomTruncateSubpaths()
+
+
+def test_random_truncate_subpaths_repr() -> None:
+    assert (
+        repr(RandomTruncateSubpaths(max_length=128, max_subpaths=16))
+        == "RandomTruncateSubpaths(max_length=128, max_subpaths=16)"
+    )

--- a/tests/transforms/subpath/test_truncate_subpaths.py
+++ b/tests/transforms/subpath/test_truncate_subpaths.py
@@ -1,0 +1,116 @@
+import pytest
+import torch
+
+from torchfont import ElementType, Outline
+from torchfont.transforms import TruncateSubpaths, functional
+
+
+@pytest.fixture
+def two_lines() -> Outline:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.END,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(5, 6)
+    coords[:, 4] = torch.arange(5)
+    return Outline(types, coords)
+
+
+def test_truncate_subpaths_keeps_longest_fitting_prefix(two_lines: Outline) -> None:
+    output = functional.truncate_subpaths(two_lines, 4)
+
+    assert output.types.tolist() == [
+        ElementType.MOVE_TO,
+        ElementType.LINE_TO,
+        ElementType.END,
+    ]
+    assert output.coords[:2, 4].tolist() == [0.0, 1.0]
+
+
+def test_truncate_subpaths_does_not_partially_keep_first_subpath(
+    two_lines: Outline,
+) -> None:
+    output = TruncateSubpaths(2)(two_lines)
+
+    assert output.types.tolist() == [ElementType.END]
+    assert output.coords.shape == (1, 6)
+
+
+def test_truncate_subpaths_counts_end_in_limit(two_lines: Outline) -> None:
+    output = TruncateSubpaths(5)(two_lines)
+
+    assert torch.equal(output.types, two_lines.types)
+    assert torch.equal(output.coords[:-1], two_lines.coords[:-1])
+
+
+def test_truncate_subpaths_accepts_index_protocol(two_lines: Outline) -> None:
+    output = TruncateSubpaths(torch.tensor(3), max_subpaths=torch.tensor(1))(two_lines)
+
+    assert len(output) == 3
+
+
+def test_truncate_subpaths_limits_subpath_count(two_lines: Outline) -> None:
+    output = TruncateSubpaths(max_subpaths=1)(two_lines)
+
+    assert output.types.tolist() == [
+        ElementType.MOVE_TO,
+        ElementType.LINE_TO,
+        ElementType.END,
+    ]
+
+
+def test_truncate_subpaths_applies_both_limits(two_lines: Outline) -> None:
+    output = TruncateSubpaths(max_length=5, max_subpaths=1)(two_lines)
+
+    assert len(output) == 3
+
+
+def test_zero_max_subpaths_returns_empty_outline(two_lines: Outline) -> None:
+    output = functional.truncate_subpaths(two_lines, max_subpaths=0)
+
+    assert output.types.tolist() == [ElementType.END]
+
+
+@pytest.mark.parametrize("max_length", [0, -1])
+def test_truncate_subpaths_rejects_non_positive_length(max_length: int) -> None:
+    with pytest.raises(ValueError, match="max_length must be positive"):
+        TruncateSubpaths(max_length)
+
+
+def test_functional_truncate_subpaths_rejects_non_positive_length(
+    two_lines: Outline,
+) -> None:
+    with pytest.raises(ValueError, match="max_length must be positive"):
+        functional.truncate_subpaths(two_lines, 0)
+
+
+def test_truncate_subpaths_requires_a_limit() -> None:
+    with pytest.raises(
+        ValueError, match="max_length or max_subpaths must be specified"
+    ):
+        TruncateSubpaths()
+
+
+def test_functional_truncate_subpaths_requires_a_limit(two_lines: Outline) -> None:
+    with pytest.raises(
+        ValueError, match="max_length or max_subpaths must be specified"
+    ):
+        functional.truncate_subpaths(two_lines)
+
+
+def test_truncate_subpaths_rejects_negative_subpath_count() -> None:
+    with pytest.raises(ValueError, match="max_subpaths must be non-negative"):
+        TruncateSubpaths(max_subpaths=-1)
+
+
+def test_truncate_subpaths_repr() -> None:
+    assert repr(TruncateSubpaths(128)) == "TruncateSubpaths(max_length=128)"
+    assert (
+        repr(TruncateSubpaths(max_subpaths=16)) == "TruncateSubpaths(max_subpaths=16)"
+    )

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -75,6 +75,12 @@ def _cases() -> list[tuple[str, CustomOpDef, tuple[object, ...]]]:
         ("set_subpath_start_points", ops.set_subpath_start_points, (*pair, values)),
         ("reorder_subpaths", ops.reorder_subpaths, (*pair, values)),
         ("drop_subpaths", ops.drop_subpaths, (*pair, values < 0.5)),
+        (
+            "drop_subpaths_to_fit",
+            ops.drop_subpaths_to_fit,
+            (*pair, values, 4, None),
+        ),
+        ("truncate_subpaths", ops.truncate_subpaths, (*pair, 4, None)),
         ("remove_overlap_groups", ops.remove_overlap_groups, (*pair, values)),
         (
             "split_segments",

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -292,6 +292,65 @@ def _(
 
 
 @torch.library.custom_op(
+    "torchfont::truncate_subpaths", mutates_args=(), device_types="cpu"
+)
+def truncate_subpaths(
+    types: Tensor,
+    coords: Tensor,
+    max_length: int | None,
+    max_subpaths: int | None,
+) -> tuple[Tensor, Tensor]:
+    """Keep the longest whole-subpath prefix within the given limits."""
+    out = _torchfont.truncate_subpaths(
+        *_arrays(types, coords), max_length, max_subpaths
+    )
+    return _restore(*out)
+
+
+@truncate_subpaths.register_fake
+def _(
+    types: Tensor,
+    coords: Tensor,
+    max_length: int | None,
+    max_subpaths: int | None,
+) -> tuple[Tensor, Tensor]:
+    del max_length, max_subpaths
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::drop_subpaths_to_fit", mutates_args=(), device_types="cpu"
+)
+def drop_subpaths_to_fit(
+    types: Tensor,
+    coords: Tensor,
+    removal_values: Tensor,
+    max_length: int | None,
+    max_subpaths: int | None,
+) -> tuple[Tensor, Tensor]:
+    """Drop subpaths in an explicit order until the limits are met."""
+    out = _torchfont.drop_subpaths_to_fit(
+        *_arrays(types, coords),
+        _selection(removal_values),
+        max_length,
+        max_subpaths,
+    )
+    return _restore(*out)
+
+
+@drop_subpaths_to_fit.register_fake
+def _(
+    types: Tensor,
+    coords: Tensor,
+    removal_values: Tensor,
+    max_length: int | None,
+    max_subpaths: int | None,
+) -> tuple[Tensor, Tensor]:
+    del removal_values, max_length, max_subpaths
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
     "torchfont::reverse_closed_subpaths", mutates_args=(), device_types="cpu"
 )
 def reverse_closed_subpaths(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
@@ -373,6 +432,7 @@ __all__ = [
     "bbox_center",
     "cubic_to_quad",
     "drop_subpaths",
+    "drop_subpaths_to_fit",
     "merge_curves",
     "normalize_subpath_start_points",
     "quad_to_cubic",
@@ -383,4 +443,5 @@ __all__ = [
     "reverse_closed_subpaths",
     "set_subpath_start_points",
     "split_segments",
+    "truncate_subpaths",
 ]

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -30,6 +30,19 @@ def drop_subpaths(
     coords: np.ndarray,
     drop_mask: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray]: ...
+def truncate_subpaths(
+    types: np.ndarray,
+    coords: np.ndarray,
+    max_length: int | None,
+    max_subpaths: int | None,
+) -> tuple[np.ndarray, np.ndarray]: ...
+def drop_subpaths_to_fit(
+    types: np.ndarray,
+    coords: np.ndarray,
+    removal_values: np.ndarray,
+    max_length: int | None,
+    max_subpaths: int | None,
+) -> tuple[np.ndarray, np.ndarray]: ...
 def render_bitmap(
     types: np.ndarray,
     coords: np.ndarray,

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -28,7 +28,9 @@ from torchfont.transforms._subpath import (
     RandomSubpathDropout,
     RandomSubpathOrder,
     RandomSubpathStartPoints,
+    RandomTruncateSubpaths,
     SplitSubpaths,
+    TruncateSubpaths,
 )
 from torchfont.transforms._transform import Transform
 
@@ -53,11 +55,13 @@ __all__ = [
     "RandomSubpathDropout",
     "RandomSubpathOrder",
     "RandomSubpathStartPoints",
+    "RandomTruncateSubpaths",
     "RandomVerticalFlip",
     "RemoveOverlaps",
     "RenderBitmap",
     "SplitSubpaths",
     "Transform",
+    "TruncateSubpaths",
     "VerticalFlip",
     "functional",
 ]

--- a/torchfont/transforms/_subpath.py
+++ b/torchfont/transforms/_subpath.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from operator import index
+from typing import TYPE_CHECKING, Any, ClassVar, SupportsIndex
 
 import torch
 
@@ -29,6 +30,70 @@ class SplitSubpaths(Transform):
     def transform(self, inpt: Outline, params: dict[str, Any]) -> tuple[Outline, ...]:
         del params
         return _functional.split_subpaths(inpt)
+
+
+class TruncateSubpaths(Transform):
+    """Keep the longest whole-subpath prefix within the given limits."""
+
+    def __init__(
+        self,
+        max_length: SupportsIndex | None = None,
+        max_subpaths: SupportsIndex | None = None,
+    ) -> None:
+        super().__init__()
+        self.max_length = None if max_length is None else index(max_length)
+        self.max_subpaths = None if max_subpaths is None else index(max_subpaths)
+        if self.max_length is None and self.max_subpaths is None:
+            msg = "max_length or max_subpaths must be specified"
+            raise ValueError(msg)
+        if self.max_length is not None and self.max_length < 1:
+            msg = "max_length must be positive"
+            raise ValueError(msg)
+        if self.max_subpaths is not None and self.max_subpaths < 0:
+            msg = "max_subpaths must be non-negative"
+            raise ValueError(msg)
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        del params
+        return _functional.truncate_subpaths(
+            inpt,
+            self.max_length,
+            self.max_subpaths,
+        )
+
+
+class RandomTruncateSubpaths(Transform):
+    """Randomly drop subpaths until the given limits are met."""
+
+    def __init__(
+        self,
+        max_length: SupportsIndex | None = None,
+        max_subpaths: SupportsIndex | None = None,
+    ) -> None:
+        super().__init__()
+        self.max_length = None if max_length is None else index(max_length)
+        self.max_subpaths = None if max_subpaths is None else index(max_subpaths)
+        if self.max_length is None and self.max_subpaths is None:
+            msg = "max_length or max_subpaths must be specified"
+            raise ValueError(msg)
+        if self.max_length is not None and self.max_length < 1:
+            msg = "max_length must be positive"
+            raise ValueError(msg)
+        if self.max_subpaths is not None and self.max_subpaths < 0:
+            msg = "max_subpaths must be non-negative"
+            raise ValueError(msg)
+
+    def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
+        length = max((inpt.types.size(0) for inpt in flat_inputs), default=0)
+        return {"removal_values": torch.rand(length)}
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        return _functional.drop_subpaths_to_fit(
+            inpt,
+            params["removal_values"],
+            self.max_length,
+            self.max_subpaths,
+        )
 
 
 class RandomSubpathDropout(Transform):
@@ -80,5 +145,7 @@ __all__ = [
     "RandomSubpathDropout",
     "RandomSubpathOrder",
     "RandomSubpathStartPoints",
+    "RandomTruncateSubpaths",
     "SplitSubpaths",
+    "TruncateSubpaths",
 ]

--- a/torchfont/transforms/functional/__init__.py
+++ b/torchfont/transforms/functional/__init__.py
@@ -23,10 +23,12 @@ from torchfont.transforms.functional._outline import (
 )
 from torchfont.transforms.functional._subpath import (
     drop_subpaths,
+    drop_subpaths_to_fit,
     normalize_subpath_start_points,
     reorder_subpaths,
     set_subpath_start_points,
     split_subpaths,
+    truncate_subpaths,
 )
 
 __all__ = [
@@ -34,6 +36,7 @@ __all__ = [
     "affine",
     "cubic_to_quad",
     "drop_subpaths",
+    "drop_subpaths_to_fit",
     "elastic",
     "horizontal_flip",
     "load_glyph",
@@ -49,5 +52,6 @@ __all__ = [
     "set_subpath_start_points",
     "split_segments",
     "split_subpaths",
+    "truncate_subpaths",
     "vertical_flip",
 ]

--- a/torchfont/transforms/functional/_subpath.py
+++ b/torchfont/transforms/functional/_subpath.py
@@ -7,7 +7,8 @@ so they do not define a gradient.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from operator import index
+from typing import TYPE_CHECKING, SupportsIndex
 
 import torch
 
@@ -56,6 +57,69 @@ def drop_subpaths(
     )
 
 
+def truncate_subpaths(
+    inpt: Outline,
+    max_length: SupportsIndex | None = None,
+    max_subpaths: SupportsIndex | None = None,
+) -> Outline:
+    """Keep the longest whole-subpath prefix within the given limits.
+
+    The terminal ``END`` counts toward ``max_length``. ``max_subpaths`` limits
+    the number of retained subpaths. At least one limit must be specified. No
+    subpath is partially retained.
+    """
+    max_length = None if max_length is None else index(max_length)
+    max_subpaths = None if max_subpaths is None else index(max_subpaths)
+    if max_length is None and max_subpaths is None:
+        msg = "max_length or max_subpaths must be specified"
+        raise ValueError(msg)
+    if max_length is not None and max_length < 1:
+        msg = "max_length must be positive"
+        raise ValueError(msg)
+    if max_subpaths is not None and max_subpaths < 0:
+        msg = "max_subpaths must be non-negative"
+        raise ValueError(msg)
+    return _native_outline(
+        inpt,
+        _ops.truncate_subpaths,
+        max_length,
+        max_subpaths,
+        name="truncate_subpaths",
+    )
+
+
+def drop_subpaths_to_fit(
+    inpt: Outline,
+    removal_values: Tensor,
+    max_length: SupportsIndex | None = None,
+    max_subpaths: SupportsIndex | None = None,
+) -> Outline:
+    """Drop subpaths in an explicit order until the given limits are met.
+
+    Smaller ``removal_values`` are removed first. The retained subpaths keep
+    their original order.
+    """
+    max_length = None if max_length is None else index(max_length)
+    max_subpaths = None if max_subpaths is None else index(max_subpaths)
+    if max_length is None and max_subpaths is None:
+        msg = "max_length or max_subpaths must be specified"
+        raise ValueError(msg)
+    if max_length is not None and max_length < 1:
+        msg = "max_length must be positive"
+        raise ValueError(msg)
+    if max_subpaths is not None and max_subpaths < 0:
+        msg = "max_subpaths must be non-negative"
+        raise ValueError(msg)
+    return _native_outline(
+        inpt,
+        _ops.drop_subpaths_to_fit,
+        removal_values,
+        max_length,
+        max_subpaths,
+        name="drop_subpaths_to_fit",
+    )
+
+
 def normalize_subpath_start_points(inpt: Outline) -> Outline:
     """Choose a deterministic start point for each closed subpath.
 
@@ -93,8 +157,10 @@ def reorder_subpaths(inpt: Outline, keys: Tensor) -> Outline:
 
 __all__ = [
     "drop_subpaths",
+    "drop_subpaths_to_fit",
     "normalize_subpath_start_points",
     "reorder_subpaths",
     "set_subpath_start_points",
     "split_subpaths",
+    "truncate_subpaths",
 ]


### PR DESCRIPTION
## Summary
- add deterministic TruncateSubpaths limits for encoded length and subpath count
- add RandomTruncateSubpaths with Python-sampled removal order and deterministic Rust execution
- expose functional kernels, compile support, tests, and aligned English/Japanese reference entries

## Validation
- mise run check
- mise run build
- uv run --locked --no-sync pytest tests (473 passed, 15 skipped)