### PR TITLE
Add subpath order normalization transform

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -73,7 +73,7 @@ inside an already-applied transform.
 | Containers | `Compose`, `RandomApply` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpaths | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpaths | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `NormalizeSubpathOrder`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | Geometry | `Affine`, `RandomAffine`, `RandomRotation`, `RandomScale`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `ElasticTransform`, `GaussianNoise` |
 | Output | `RenderBitmap` |
 
@@ -157,7 +157,7 @@ Gradient support varies by operation:
 | `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
 | `remove_overlaps`, `remove_overlap_groups` | no |
-| `split_subpaths`, `truncate_subpaths`, `drop_subpaths`, `drop_subpaths_to_fit`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
+| `split_subpaths`, `truncate_subpaths`, `drop_subpaths`, `drop_subpaths_to_fit`, `normalize_subpath_start_points`, `normalize_subpath_order`, `set_subpath_start_points`, `reorder_subpaths` | no |
 | `render_bitmap` | no |
 
 Passing an outline that requires grad to an operation marked "no" raises:

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -72,7 +72,7 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | コンテナ | `Compose`, `RandomApply` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
-| Subpath | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
+| Subpath | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `NormalizeSubpathOrder`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |
 | 幾何変換 | `Affine`, `RandomAffine`, `RandomRotation`, `RandomScale`, `HorizontalFlip`, `VerticalFlip`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `ElasticTransform`, `GaussianNoise` |
 | 出力 | `RenderBitmap` |
 
@@ -154,7 +154,7 @@ Functional API は乱数を生成しません。ランダムな選択とパラ�
 | `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
 | `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
 | `remove_overlaps`, `remove_overlap_groups` | いいえ |
-| `split_subpaths`, `truncate_subpaths`, `drop_subpaths`, `drop_subpaths_to_fit`, `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
+| `split_subpaths`, `truncate_subpaths`, `drop_subpaths`, `drop_subpaths_to_fit`, `normalize_subpath_start_points`, `normalize_subpath_order`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
 | `render_bitmap` | いいえ |
 
 「いいえ」の処理に勾配を要求する Outline を渡すとエラーになります。

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -296,6 +296,17 @@ pub(crate) fn randomize_subpath_order<'py>(
 }
 
 #[pyfunction]
+pub(crate) fn normalize_subpath_order<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<OutlineArrays<'py>> {
+    let outline = decode(types.as_slice()?, coords.as_slice()?)?;
+    let result = py.detach(|| subpath::normalize_subpath_order(&outline));
+    Ok(encode(py, &result))
+}
+
+#[pyfunction]
 pub(crate) fn reverse_closed_subpaths<'py>(
     py: Python<'py>,
     types: PyReadonlyArray1<'_, i64>,
@@ -419,6 +430,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(random_remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;
+    m.add_function(wrap_pyfunction!(normalize_subpath_order, m)?)?;
     m.add_function(wrap_pyfunction!(randomize_subpath_order, m)?)?;
     m.add_function(wrap_pyfunction!(randomize_subpath_start_points, m)?)?;
     m.add_function(wrap_pyfunction!(reverse_closed_subpaths, m)?)?;

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 use crate::outline::outline_from_subpaths;
 use crate::outline::{
-    BezPath, PathEl, Point, path_element_end, subpath_elements, subpath_from_elements,
-    subpath_is_closed, subpath_start,
+    BezPath, Bounds, PathEl, Point, bounds_from_subpath, path_element_end, subpath_elements,
+    subpath_from_elements, subpath_is_closed, subpath_start,
 };
 
 pub(crate) fn reverse_subpath(subpath: &[PathEl]) -> BezPath {
@@ -110,6 +110,27 @@ pub(crate) fn randomize_subpath_order(outline: &BezPath, random_values: &[f32]) 
         result.extend(subpath.iter().copied());
     }
     result
+}
+
+pub(crate) fn normalize_subpath_order(outline: &BezPath) -> BezPath {
+    let mut subpaths: Vec<_> = outline.subpaths().enumerate().collect();
+    subpaths.sort_by(|(a_idx, a), (b_idx, b)| {
+        compare_bounds(bounds_from_subpath(a), bounds_from_subpath(b))
+            .then_with(|| a_idx.cmp(b_idx))
+    });
+    let mut result = BezPath::new();
+    for (_, subpath) in subpaths {
+        result.extend(subpath.iter().copied());
+    }
+    result
+}
+
+fn compare_bounds(a: Bounds, b: Bounds) -> std::cmp::Ordering {
+    a.x_min
+        .total_cmp(&b.x_min)
+        .then_with(|| a.y_min.total_cmp(&b.y_min))
+        .then_with(|| a.x_max.total_cmp(&b.x_max))
+        .then_with(|| a.y_max.total_cmp(&b.y_max))
 }
 
 pub(crate) fn reverse_closed_subpaths(outline: &BezPath) -> BezPath {
@@ -396,6 +417,49 @@ mod tests {
         let outline = outline_from_subpaths([first.clone(), second.clone()]);
 
         let result = randomize_subpath_order(&outline, &[0.5, 0.5]);
+
+        assert_eq!(subpaths(&result), vec![first, second]);
+    }
+
+    #[test]
+    fn normalize_subpath_order_uses_tight_bounds() {
+        let first = closed(pt(10.0, 0.0), vec![line(11.0, 0.0)]);
+        let second = closed(pt(0.0, 10.0), vec![line(1.0, 10.0)]);
+        let third = closed(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let outline = outline_from_subpaths([first.clone(), second.clone(), third.clone()]);
+
+        let result = normalize_subpath_order(&outline);
+
+        assert_eq!(subpaths(&result), vec![third, second, first]);
+    }
+
+    #[test]
+    fn normalize_subpath_order_does_not_depend_on_start_point_or_winding() {
+        let right = closed(pt(10.0, 0.0), vec![line(12.0, 0.0), line(11.0, 1.0)]);
+        let left = closed(pt(2.0, 0.0), vec![line(0.0, 0.0), line(1.0, 1.0)]);
+        let outline = outline_from_subpaths([right.clone(), left.clone()]);
+        let changed = outline_from_subpaths([reverse_subpath(right.elements()), left.clone()]);
+
+        assert_eq!(
+            subpaths(&normalize_subpath_order(&outline)),
+            vec![left.clone(), right.clone()]
+        );
+        assert_eq!(
+            subpaths(&normalize_subpath_order(&changed)),
+            vec![left, reverse_subpath(right.elements())]
+        );
+    }
+
+    #[test]
+    fn normalize_subpath_order_preserves_tie_order() {
+        let first = open(pt(0.0, 0.0), vec![line(1.0, 1.0)]);
+        let second = open(
+            pt(0.0, 0.0),
+            vec![PathEl::QuadTo(pt(0.5, 0.5), pt(1.0, 1.0))],
+        );
+        let outline = outline_from_subpaths([first.clone(), second.clone()]);
+
+        let result = normalize_subpath_order(&outline);
 
         assert_eq!(subpaths(&result), vec![first, second]);
     }

--- a/tests/transforms/subpath/test_normalize_subpath_order.py
+++ b/tests/transforms/subpath/test_normalize_subpath_order.py
@@ -1,0 +1,70 @@
+import torch
+
+from torchfont import ElementType, Outline
+from torchfont.transforms import NormalizeSubpathOrder
+from torchfont.transforms import functional as F  # noqa: N812
+
+
+def _two_squares() -> Outline:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.LINE_TO,
+            ElementType.CLOSE,
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.LINE_TO,
+            ElementType.CLOSE,
+            ElementType.END,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0, 0, 0, 0, 2.0, 2.0],
+            [0, 0, 0, 0, 3.0, 2.0],
+            [0, 0, 0, 0, 2.0, 3.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 1.0, 1.0],
+            [0, 0, 0, 0, 2.0, 1.0],
+            [0, 0, 0, 0, 1.0, 2.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    return Outline(types, coords)
+
+
+def test_normalize_subpath_order_sorts_by_tight_bounds() -> None:
+    output = NormalizeSubpathOrder()(_two_squares())
+
+    assert output.coords[0, 4:6].tolist() == [1.0, 1.0]
+    assert output.coords[4, 4:6].tolist() == [2.0, 2.0]
+
+
+def test_normalize_subpath_order_does_not_depend_on_start_point() -> None:
+    outline = _two_squares()
+    rotated_coords = outline.coords.clone()
+    rotated_coords[:3, 4:6] = rotated_coords[[1, 2, 0], 4:6]
+
+    output = F.normalize_subpath_order(Outline(outline.types, rotated_coords))
+
+    assert output.coords[0, 4:6].tolist() == [1.0, 1.0]
+    assert output.coords[4, 4:6].tolist() == [3.0, 2.0]
+
+
+def test_normalize_subpath_order_is_idempotent() -> None:
+    once = F.normalize_subpath_order(_two_squares())
+    twice = F.normalize_subpath_order(once)
+
+    assert torch.equal(twice.types, once.types)
+    assert torch.equal(twice.coords, once.coords)
+
+
+def test_normalize_subpath_order_preserves_rendering() -> None:
+    outline = _two_squares()
+    output = F.normalize_subpath_order(outline)
+
+    assert torch.equal(F.render_bitmap(output, 64), F.render_bitmap(outline, 64))

--- a/tests/transforms/test_autograd.py
+++ b/tests/transforms/test_autograd.py
@@ -102,6 +102,7 @@ def test_flip_without_winding_preservation_is_differentiable() -> None:
         ("merge_curves", F.merge_curves),
         ("remove_overlaps", F.remove_overlaps),
         ("render_bitmap", F.render_bitmap),
+        ("normalize_subpath_order", F.normalize_subpath_order),
         ("normalize_subpath_start_points", F.normalize_subpath_start_points),
         ("horizontal_flip", F.horizontal_flip),
         ("vertical_flip", F.vertical_flip),

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -45,6 +45,7 @@ def _pipeline(types: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
     outline = F.scale(outline, (0.9, 1.1))
     outline = F.elastic(outline, coords.new_zeros((1, 4, 4, 2)))
     outline = F.normalize_subpath_start_points(outline)
+    outline = F.normalize_subpath_order(outline)
     return F.render_bitmap(outline, 32)
 
 
@@ -70,6 +71,7 @@ def _cases() -> list[tuple[str, CustomOpDef, tuple[object, ...]]]:
             ops.normalize_subpath_start_points,
             pair,
         ),
+        ("normalize_subpath_order", ops.normalize_subpath_order, pair),
         ("reverse_closed_subpaths", ops.reverse_closed_subpaths, pair),
         ("bbox_center", ops.bbox_center, pair),
         ("set_subpath_start_points", ops.set_subpath_start_points, (*pair, values)),

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -230,6 +230,22 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
+    "torchfont::normalize_subpath_order",
+    mutates_args=(),
+    device_types="cpu",
+)
+def normalize_subpath_order(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Order subpaths lexicographically by their tight bounding boxes."""
+    out = _torchfont.normalize_subpath_order(*_arrays(types, coords))
+    return _restore(*out)
+
+
+@normalize_subpath_order.register_fake
+def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
     "torchfont::set_subpath_start_points", mutates_args=(), device_types="cpu"
 )
 def set_subpath_start_points(
@@ -434,6 +450,7 @@ __all__ = [
     "drop_subpaths",
     "drop_subpaths_to_fit",
     "merge_curves",
+    "normalize_subpath_order",
     "normalize_subpath_start_points",
     "quad_to_cubic",
     "remove_overlap_groups",

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -54,6 +54,9 @@ def render_bitmap(
 def normalize_subpath_start_points(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]: ...
+def normalize_subpath_order(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]: ...
 def randomize_subpath_order(
     types: np.ndarray, coords: np.ndarray, random_values: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]: ...

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -24,6 +24,7 @@ from torchfont.transforms._geometry import (
 from torchfont.transforms._glyph import LoadGlyph
 from torchfont.transforms._outline import RandomRemoveOverlaps, RemoveOverlaps
 from torchfont.transforms._subpath import (
+    NormalizeSubpathOrder,
     NormalizeSubpathStartPoints,
     RandomSubpathDropout,
     RandomSubpathOrder,
@@ -43,6 +44,7 @@ __all__ = [
     "HorizontalFlip",
     "LoadGlyph",
     "MergeCurves",
+    "NormalizeSubpathOrder",
     "NormalizeSubpathStartPoints",
     "QuadToCubic",
     "RandomAffine",

--- a/torchfont/transforms/_subpath.py
+++ b/torchfont/transforms/_subpath.py
@@ -24,6 +24,14 @@ class NormalizeSubpathStartPoints(Transform):
         return _functional.normalize_subpath_start_points(inpt)
 
 
+class NormalizeSubpathOrder(Transform):
+    """Order subpaths lexicographically by their tight bounding boxes."""
+
+    def transform(self, inpt: Outline, params: dict[str, Any]) -> Outline:
+        del params
+        return _functional.normalize_subpath_order(inpt)
+
+
 class SplitSubpaths(Transform):
     """Split each outline into a tuple of independently encoded subpaths."""
 
@@ -141,6 +149,7 @@ class RandomSubpathOrder(_RandomSubpathTransform):
 
 
 __all__ = [
+    "NormalizeSubpathOrder",
     "NormalizeSubpathStartPoints",
     "RandomSubpathDropout",
     "RandomSubpathOrder",

--- a/torchfont/transforms/functional/__init__.py
+++ b/torchfont/transforms/functional/__init__.py
@@ -24,6 +24,7 @@ from torchfont.transforms.functional._outline import (
 from torchfont.transforms.functional._subpath import (
     drop_subpaths,
     drop_subpaths_to_fit,
+    normalize_subpath_order,
     normalize_subpath_start_points,
     reorder_subpaths,
     set_subpath_start_points,
@@ -41,6 +42,7 @@ __all__ = [
     "horizontal_flip",
     "load_glyph",
     "merge_curves",
+    "normalize_subpath_order",
     "normalize_subpath_start_points",
     "quad_to_cubic",
     "remove_overlap_groups",

--- a/torchfont/transforms/functional/_subpath.py
+++ b/torchfont/transforms/functional/_subpath.py
@@ -135,6 +135,20 @@ def normalize_subpath_start_points(inpt: Outline) -> Outline:
     )
 
 
+def normalize_subpath_order(inpt: Outline) -> Outline:
+    """Order subpaths lexicographically by their tight bounding boxes.
+
+    The sort key is ``(x_min, y_min, x_max, y_max)``. It is independent of the
+    start point and winding. Ties preserve the input order, and element
+    encodings within each subpath are unchanged.
+    """
+    return _native_outline(
+        inpt,
+        _ops.normalize_subpath_order,
+        name="normalize_subpath_order",
+    )
+
+
 def set_subpath_start_points(inpt: Outline, selection_values: Tensor) -> Outline:
     """Set closed-subpath start points from explicit unit-interval values."""
     return _native_outline(
@@ -158,6 +172,7 @@ def reorder_subpaths(inpt: Outline, keys: Tensor) -> Outline:
 __all__ = [
     "drop_subpaths",
     "drop_subpaths_to_fit",
+    "normalize_subpath_order",
     "normalize_subpath_start_points",
     "reorder_subpaths",
     "set_subpath_start_points",


### PR DESCRIPTION
## Summary

- add `NormalizeSubpathOrder` and `functional.normalize_subpath_order`
- sort subpaths by tight bounding boxes without changing start points or winding
- expose the Rust kernel through the native and PyTorch custom-op layers
- document the transform in English and Japanese

## Testing

- `mise run check`
- `uv run --locked --no-sync pytest tests`
- `mise run docs-build`
