### PR TITLE
Add random transform containers

### DIFF
--- a/docs/en/guide/basic/what-is-torchfont.md
+++ b/docs/en/guide/basic/what-is-torchfont.md
@@ -26,5 +26,6 @@ of that work:
   from the original files without a required preprocessing format.
 - **Composable transforms**:
   an `Outline`-aware class API provides `torchvision.transforms.v2`-style `Transform`,
-  `Compose`, and `RandomApply` building blocks for reusable data pipelines.
+  `Compose`, `RandomApply`, `RandomChoice`, and `RandomOrder` building blocks for
+  reusable data pipelines.
   Deterministic functionals remain available as low-level kernels.

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -53,8 +53,9 @@ Transforms accept nested inputs and preserve their structure. Corresponding
 outlines in one call receive the same randomly sampled parameters. Apply the
 transform separately to independent samples. Random transforms use PyTorch's default RNG, so
 `torch.manual_seed` and DataLoader worker seeding apply normally.
-Built-in transforms can be used with multiprocessing data loaders. `Compose`
-accepts `nn.Module` transforms; define custom transforms as `nn.Module`
+Built-in transforms can be used with multiprocessing data loaders. `Compose`,
+`RandomChoice`, and `RandomOrder`
+accept `nn.Module` transforms; define custom transforms as `nn.Module`
 subclasses rather than plain callables. An empty `Compose` leaves its input
 unchanged. Use `Compose` inside `RandomApply` to group several transforms.
 
@@ -62,6 +63,11 @@ Calling `eval()` does not disable random data augmentation. Use a deterministic
 pipeline for evaluation.
 
 `RandomApply(transform, p)` controls whether one transform is applied.
+`RandomChoice(transforms, p)` applies one randomly selected transform, with equal
+probability when `p` is omitted. The weights in `p` are normalized automatically.
+`RandomOrder(transforms)` applies every transform once in a randomly selected order.
+The transforms passed to `RandomOrder` must
+accept the output types produced by every possible preceding order.
 Probabilities such as `RandomSplitSegments.split_probability` control behavior
 inside an already-applied transform.
 
@@ -70,7 +76,7 @@ inside an already-applied transform.
 | Category | Transforms |
 | --- | --- |
 | Loading | `LoadGlyph` |
-| Containers | `Compose`, `RandomApply` |
+| Containers | `Compose`, `RandomApply`, `RandomChoice`, `RandomOrder` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
 | Subpaths | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `NormalizeSubpathOrder`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |

--- a/docs/ja/guide/basic/what-is-torchfont.md
+++ b/docs/ja/guide/basic/what-is-torchfont.md
@@ -25,5 +25,6 @@ TorchFont は PyTorch の非公式ライブラリです。PyTorch プロジェ�
   専用の中間形式への事前変換は必要ありません。
 - **組み合わせ可能な変換**:
   `Outline` を認識するクラス API と、`torchvision.transforms.v2` 形式の `Transform`、`Compose`、
-  `RandomApply` を再利用可能なパイプライン向けに提供します。決定的な Functional API は
+  `RandomApply`、`RandomChoice`、`RandomOrder` を再利用可能なパイプライン向けに提供します。
+  決定的な Functional API は
   低レベルカーネルとして利用できます。

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -52,7 +52,8 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 独立したサンプルには Transform を個別に適用します。確率的 Transform は PyTorch の
 デフォルト RNG を使うため、`torch.manual_seed` と `DataLoader` ワーカーのシードが通常どおり
 機能します。
-組み込み Transform はマルチプロセスの DataLoader でも使用できます。`Compose` には
+組み込み Transform はマルチプロセスの DataLoader でも使用できます。`Compose`、
+`RandomChoice`、`RandomOrder` には
 `nn.Module` の Transform を渡します。独自 Transform も通常の Callable ではなく
 `nn.Module` の Subclass として定義してください。空の `Compose` は入力を変更しません。
 複数の Transform を `RandomApply` でまとめる場合は、内側に `Compose` を置きます。
@@ -61,6 +62,11 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 決定論的な Pipeline を使用してください。
 
 `RandomApply(transform, p)` は一つの Transform を適用するか制御します。
+`RandomChoice(transforms, p)` はランダムに選んだ一つの Transform を適用し、`p` を
+省略すると等確率で選びます。`p` の重みは自動的に正規化されます。
+`RandomOrder(transforms)` はすべての Transform をランダムな
+順序で一度ずつ適用します。`RandomOrder` に渡す各 Transform は、先行し得るすべての順序が
+生成する出力型を受け取れる必要があります。
 `RandomSplitSegments.split_probability` などは、適用された Transform 内部の挙動を
 制御します。
 
@@ -69,7 +75,7 @@ Transform はネストした入力を受け取り、その構造を保ちます�
 | 分類 | Transform |
 | --- | --- |
 | 読み込み | `LoadGlyph` |
-| コンテナ | `Compose`, `RandomApply` |
+| コンテナ | `Compose`, `RandomApply`, `RandomChoice`, `RandomOrder` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
 | Subpath | `SplitSubpaths`, `TruncateSubpaths`, `RandomTruncateSubpaths`, `RandomSubpathDropout`, `NormalizeSubpathStartPoints`, `NormalizeSubpathOrder`, `RandomSubpathStartPoints`, `RandomSubpathOrder` |

--- a/tests/transforms/test_transform.py
+++ b/tests/transforms/test_transform.py
@@ -17,6 +17,8 @@ from torchfont.transforms import (
     LoadGlyph,
     QuadToCubic,
     RandomApply,
+    RandomChoice,
+    RandomOrder,
     RandomSplitSegments,
     RenderBitmap,
     Transform,
@@ -30,6 +32,15 @@ class AddToCoords(Transform):
 
     def transform(self, outline: Outline, _params: dict[str, object]) -> Outline:
         return Outline(outline.types, outline.coords + self.value)
+
+
+class MultiplyCoords(Transform):
+    def __init__(self, value: float) -> None:
+        super().__init__()
+        self.value = value
+
+    def transform(self, outline: Outline, _params: dict[str, object]) -> Outline:
+        return Outline(outline.types, outline.coords * self.value)
 
 
 class IncrementInts(Transform):
@@ -152,6 +163,104 @@ def test_random_apply_rejects_plain_callables() -> None:
 def test_random_apply_rejects_invalid_probability(p: float) -> None:
     with pytest.raises(ValueError, match="p must be between 0 and 1"):
         RandomApply(AddToCoords(1.0), p=p)
+
+
+@pytest.mark.parametrize(("p", "expected"), [([1.0, 0.0], 1.0), ([0.0, 1.0], 2.0)])
+def test_random_choice_selects_transform(
+    p: list[float],
+    expected: float,
+) -> None:
+    outline = _line_outline()
+    transform = RandomChoice([AddToCoords(1.0), AddToCoords(2.0)], p=p)
+
+    output = transform(outline)
+
+    assert torch.equal(output.coords, outline.coords + expected)
+
+
+def test_random_choice_normalizes_probabilities() -> None:
+    transform = RandomChoice([AddToCoords(1.0), AddToCoords(2.0)], p=[1.0, 3.0])
+
+    assert transform.p == [0.25, 0.75]
+
+
+def test_random_choice_supports_multiple_inputs() -> None:
+    outline = _line_outline()
+    transform = RandomChoice([AddToCoords(2.0)], p=[1.0])
+
+    output = transform(outline, "label")
+
+    assert isinstance(output, tuple)
+    assert torch.equal(output[0].coords, outline.coords + 2.0)
+    assert output[1] == "label"
+
+
+@pytest.mark.parametrize(
+    ("p", "match"),
+    [
+        ([1.0], "p length must match"),
+        ([-1.0, 2.0], "non-negative and finite"),
+        ([float("inf"), 1.0], "non-negative and finite"),
+        ([0.0, 0.0], "positive sum"),
+    ],
+)
+def test_random_choice_rejects_invalid_probabilities(
+    p: list[float],
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        RandomChoice([AddToCoords(1.0), AddToCoords(2.0)], p=p)
+
+
+@pytest.mark.parametrize("container", [RandomChoice, RandomOrder])
+def test_random_containers_reject_empty_transforms(
+    container: type[RandomChoice] | type[RandomOrder],
+) -> None:
+    with pytest.raises(ValueError, match="at least one transform"):
+        container([])
+
+
+@pytest.mark.parametrize("container", [RandomChoice, RandomOrder])
+def test_random_containers_register_transforms(
+    container: type[RandomChoice] | type[RandomOrder],
+) -> None:
+    child = AddToCoords(1.0)
+    transform = container([child])
+
+    assert transform.get_submodule("transforms.0") is child
+
+
+@pytest.mark.parametrize("container", [RandomChoice, RandomOrder])
+def test_random_containers_reject_plain_callables(
+    container: type[RandomChoice] | type[RandomOrder],
+) -> None:
+    with pytest.raises(TypeError, match="is not a Module subclass"):
+        container([lambda value: value])  # ty: ignore[invalid-argument-type]
+
+
+def test_random_order_applies_each_transform_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch, "randperm", lambda _length: torch.tensor([1, 0]))
+    transform = RandomOrder([AddToCoords(1.0), MultiplyCoords(2.0)])
+    outline = _line_outline()
+
+    output = transform(outline)
+
+    assert torch.equal(output.coords, outline.coords * 2.0 + 1.0)
+
+
+def test_random_order_supports_multiple_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch, "randperm", lambda _length: torch.tensor([0]))
+    outline = _line_outline()
+
+    output = RandomOrder([AddToCoords(2.0)])(outline, "label")
+
+    assert isinstance(output, tuple)
+    assert torch.equal(output[0].coords, outline.coords + 2.0)
+    assert output[1] == "label"
 
 
 def test_random_split_segments_handles_different_length_outlines() -> None:

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -2,7 +2,12 @@
 
 from torchfont.transforms import functional
 from torchfont.transforms._bitmap import RenderBitmap
-from torchfont.transforms._container import Compose, RandomApply
+from torchfont.transforms._container import (
+    Compose,
+    RandomApply,
+    RandomChoice,
+    RandomOrder,
+)
 from torchfont.transforms._curves import (
     CubicToQuad,
     MergeCurves,
@@ -49,7 +54,9 @@ __all__ = [
     "QuadToCubic",
     "RandomAffine",
     "RandomApply",
+    "RandomChoice",
     "RandomHorizontalFlip",
+    "RandomOrder",
     "RandomRemoveOverlaps",
     "RandomRotation",
     "RandomScale",

--- a/torchfont/transforms/_container.py
+++ b/torchfont/transforms/_container.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, cast
 
 import torch
@@ -70,4 +71,68 @@ class RandomApply(nn.Module):
         return f"p={self.p}"
 
 
-__all__ = ["Compose", "RandomApply"]
+class RandomChoice(nn.Module):
+    """Apply one transform randomly selected from a sequence."""
+
+    def __init__(
+        self,
+        transforms: Iterable[nn.Module] | nn.ModuleList,
+        p: list[float] | None = None,
+    ) -> None:
+        super().__init__()
+        self.transforms = _module_list(transforms)
+        if not self.transforms:
+            msg = "transforms must contain at least one transform"
+            raise ValueError(msg)
+        if p is None:
+            p = [1.0] * len(self.transforms)
+        elif len(p) != len(self.transforms):
+            msg = (
+                "p length must match the number of transforms, "
+                f"got {len(p)} and {len(self.transforms)}"
+            )
+            raise ValueError(msg)
+        if not all(
+            math.isfinite(probability) and probability >= 0.0 for probability in p
+        ):
+            msg = "p values must be non-negative and finite"
+            raise ValueError(msg)
+        total = sum(p)
+        if total == 0.0:
+            msg = "p values must have a positive sum"
+            raise ValueError(msg)
+        self.p = [probability / total for probability in p]
+
+    def forward(self, *inputs: object) -> object:
+        """Apply the randomly selected transform to all inputs."""
+        index = int(torch.multinomial(torch.tensor(self.p), 1).item())
+        return self.transforms[index](*inputs)
+
+    def extra_repr(self) -> str:
+        return f"p={self.p}"
+
+
+class RandomOrder(nn.Module):
+    """Apply a sequence of transforms in random order."""
+
+    def __init__(
+        self,
+        transforms: Iterable[nn.Module] | nn.ModuleList,
+    ) -> None:
+        super().__init__()
+        self.transforms = _module_list(transforms)
+        if not self.transforms:
+            msg = "transforms must contain at least one transform"
+            raise ValueError(msg)
+
+    def forward(self, *inputs: object) -> object:
+        """Apply all configured transforms in a randomly sampled order."""
+        unpack = len(inputs) > 1
+        output: object = inputs if unpack else inputs[0]
+        for transform_index in torch.randperm(len(self.transforms)):
+            output = self.transforms[transform_index](*inputs)
+            inputs = cast("tuple[object, ...]", output) if unpack else (output,)
+        return output
+
+
+__all__ = ["Compose", "RandomApply", "RandomChoice", "RandomOrder"]


### PR DESCRIPTION
## Summary

- add `RandomChoice` with normalized selection weights
- add `RandomOrder` with TorchVision-style random composition
- register child transforms as modules and document the public APIs in English and Japanese

## Testing

- `mise run test`
- `mise run check`
- `mise run docs-build`