### PR TITLE
Release v0.13.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     given-names: "Takumu"
     email: "fjktkm@gmail.com"
     orcid: "https://orcid.org/0009-0005-0691-414X"
-version: 0.13.1
-date-released: 2026-08-25
+version: 0.13.2
+date-released: 2026-08-26
 license: MIT
 repository-code: "https://github.com/torchfont/torchfont"
 url: "https://torchfont.readthedocs.io/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.13.2 in `Cargo.toml`/`Cargo.lock` and `CITATION.cff`, per the release process in CONTRIBUTING.md.

## Test plan
- [x] `mise run --force format`
- [x] `mise run --force check`
- [ ] CI passes on this PR