### PR TITLE
Expose dataset outline lengths

### DIFF
--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -54,6 +54,7 @@ Properties:
 - `character_classes -> list[str]`
 - `character_class_to_idx -> dict[str, int]`
 - `character_targets -> LongTensor (N,)`
+- `outline_lengths -> LongTensor (N,)`
 
 The sampling distribution is proportional to the number of supported
 codepoints in each face. Adjust training weights with a PyTorch sampler when the
@@ -92,6 +93,7 @@ Properties:
 - `font_classes -> list[FontRef]`
 - `font_targets -> LongTensor (N,)`
 - `glyph_ids -> LongTensor (N,)`
+- `outline_lengths -> LongTensor (N,)`
 
 `glyph_ids` holds the face-local glyph id of each sample. Ids are not
 comparable across faces, so they are data for selecting samples rather than
@@ -111,6 +113,9 @@ dataset = GlyphIdDataset(root="data/google/fonts", max_length=128)
 
 Faces left without a fitting glyph are omitted, as they are for the other
 filters.
+
+`outline_lengths` contains each pre-transform encoded length, including the
+trailing `END` element, at the face's default variation location.
 
 ## Loading glyphs
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -54,6 +54,7 @@ dataset = CodepointDataset(
 - `character_classes -> list[str]`
 - `character_class_to_idx -> dict[str, int]`
 - `character_targets -> LongTensor (N,)`
+- `outline_lengths -> LongTensor (N,)`
 
 サンプリング分布は各フェイスが収録するコードポイント数に比例します。異なる分布が必要な用途では
 PyTorch のサンプラーで学習時の重みを調整してください。
@@ -91,6 +92,7 @@ dataset = GlyphIdDataset(
 - `font_classes -> list[FontRef]`
 - `font_targets -> LongTensor (N,)`
 - `glyph_ids -> LongTensor (N,)`
+- `outline_lengths -> LongTensor (N,)`
 
 `glyph_ids` は各サンプルのフェイスローカルなグリフ ID です。フェイスをまたいで比較できる値では
 ないため、学習ターゲットではなくサンプル選択のためのデータとして使ってください。
@@ -107,6 +109,9 @@ dataset = GlyphIdDataset(root="data/google/fonts", max_length=128)
 ```
 
 条件を満たすグリフが 1 つも残らないフェイスは、他のフィルターと同様に除外されます。
+
+`outline_lengths` は、末尾の `END` 要素を含む変換前の符号化長を、フェイスのデフォルトの
+バリエーション位置で保持します。
 
 ## グリフのロード
 

--- a/src/dataset/discovered_font.rs
+++ b/src/dataset/discovered_font.rs
@@ -16,6 +16,7 @@ pub(crate) struct DiscoveredCodepoints {
     face_index: u32,
     codepoints: Vec<u32>,
     glyph_ids: Vec<u32>,
+    outline_lengths: Vec<u32>,
 }
 
 /// One discovered face and every glyph id it draws an outline for.
@@ -23,6 +24,7 @@ pub(crate) struct DiscoveredGlyphs {
     path: PathBuf,
     face_index: u32,
     glyph_ids: Vec<u32>,
+    outline_lengths: Vec<u32>,
 }
 
 impl DiscoveredCodepoints {
@@ -36,8 +38,14 @@ impl DiscoveredCodepoints {
         })
     }
 
-    pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>, Vec<u32>) {
-        (self.path, self.face_index, self.codepoints, self.glyph_ids)
+    pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>, Vec<u32>, Vec<u32>) {
+        (
+            self.path,
+            self.face_index,
+            self.codepoints,
+            self.glyph_ids,
+            self.outline_lengths,
+        )
     }
 
     pub(crate) fn codepoint_count(&self) -> usize {
@@ -60,23 +68,27 @@ impl DiscoveredCodepoints {
             let Some(glyph) = outline_glyphs.get(glyph_id) else {
                 continue;
             };
-            if let Some(max_length) = max_length
-                && !fits_max_length(path, face_index, glyph_id, &glyph, max_length)?
-            {
+            let length = glyph_length(path, face_index, glyph_id, &glyph)?;
+            if max_length.is_some_and(|maximum| length as usize > maximum) {
                 continue;
             }
-            mappings.push((codepoint, glyph_id));
+            mappings.push((codepoint, glyph_id, length));
         }
         mappings.sort_unstable_by_key(|entry| entry.0);
-        let (codepoints, glyph_ids) = mappings
-            .into_iter()
-            .map(|(codepoint, glyph_id)| (codepoint, glyph_id.to_u32()))
-            .unzip();
+        let mut codepoints = Vec::with_capacity(mappings.len());
+        let mut glyph_ids = Vec::with_capacity(mappings.len());
+        let mut outline_lengths = Vec::with_capacity(mappings.len());
+        for (codepoint, glyph_id, length) in mappings {
+            codepoints.push(codepoint);
+            glyph_ids.push(glyph_id.to_u32());
+            outline_lengths.push(length);
+        }
         Ok(Self {
             path: path.to_path_buf(),
             face_index,
             codepoints,
             glyph_ids,
+            outline_lengths,
         })
     }
 }
@@ -88,8 +100,13 @@ impl DiscoveredGlyphs {
         })
     }
 
-    pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>) {
-        (self.path, self.face_index, self.glyph_ids)
+    pub(crate) fn into_parts(self) -> (PathBuf, u32, Vec<u32>, Vec<u32>) {
+        (
+            self.path,
+            self.face_index,
+            self.glyph_ids,
+            self.outline_lengths,
+        )
     }
 
     pub(crate) fn glyph_count(&self) -> usize {
@@ -103,33 +120,34 @@ impl DiscoveredGlyphs {
         max_length: Option<usize>,
     ) -> Result<Self, Error> {
         let mut glyph_ids = Vec::new();
+        let mut outline_lengths = Vec::new();
         for (glyph_id, glyph) in font.outline_glyphs().iter() {
-            if let Some(max_length) = max_length
-                && !fits_max_length(path, face_index, glyph_id, &glyph, max_length)?
-            {
+            let length = glyph_length(path, face_index, glyph_id, &glyph)?;
+            if max_length.is_some_and(|maximum| length as usize > maximum) {
                 continue;
             }
             glyph_ids.push(glyph_id.to_u32());
+            outline_lengths.push(length);
         }
         Ok(Self {
             path: path.to_path_buf(),
             face_index,
             glyph_ids,
+            outline_lengths,
         })
     }
 }
 
-/// Whether the encoded sequence of one glyph fits within `max_length`.
+/// Returns the encoded sequence length of one glyph.
 ///
 /// The elements are counted at the face default location, where variations
 /// move points without changing how many elements a glyph draws.
-fn fits_max_length(
+fn glyph_length(
     path: &Path,
     face_index: u32,
     glyph_id: GlyphId,
     glyph: &OutlineGlyph<'_>,
-    max_length: usize,
-) -> Result<bool, Error> {
+) -> Result<u32, Error> {
     let length = count_glyph_elements(
         glyph,
         DrawSettings::unhinted(Size::unscaled(), LocationRef::default()),
@@ -141,7 +159,13 @@ fn fits_max_length(
             path.display()
         ))
     })?;
-    Ok(length <= max_length)
+    u32::try_from(length).map_err(|_| {
+        Error::Parse(format!(
+            "glyph id {} of '{}' (face_index {face_index}) has too many elements",
+            glyph_id.to_u32(),
+            path.display()
+        ))
+    })
 }
 
 /// Parses every face in one font file and builds one entry per face.

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -2,11 +2,11 @@ use std::path::PathBuf;
 
 /// One discovered face: its file, face index, and the codepoint/glyph id pairs
 /// it contributes, sorted by codepoint.
-pub(crate) type IndexedCodepointFace = (PathBuf, u32, Vec<u32>, Vec<u32>);
+pub(crate) type IndexedCodepointFace = (PathBuf, u32, Vec<u32>, Vec<u32>, Vec<u32>);
 
 /// One discovered face: its file, face index, and the glyph ids it contributes,
 /// sorted in ascending order.
-pub(crate) type IndexedGlyphFace = (PathBuf, u32, Vec<u32>);
+pub(crate) type IndexedGlyphFace = (PathBuf, u32, Vec<u32>, Vec<u32>);
 
 /// Flat sample index over the `cmap` entries of discovered font faces.
 ///
@@ -20,6 +20,7 @@ pub(crate) struct CodepointIndex {
     pub(crate) character_codepoints: Vec<u32>,
     pub(crate) character_index: Vec<u32>,
     pub(crate) glyph_ids: Vec<u32>,
+    pub(crate) outline_lengths: Vec<u32>,
 }
 
 /// Flat sample index over every outline glyph of discovered font faces.
@@ -30,6 +31,7 @@ pub(crate) struct GlyphIndex {
     pub(crate) fonts: Vec<(PathBuf, u32)>,
     pub(crate) offsets: Vec<i64>,
     pub(crate) glyph_ids: Vec<u32>,
+    pub(crate) outline_lengths: Vec<u32>,
 }
 
 impl CodepointIndex {
@@ -40,13 +42,16 @@ impl CodepointIndex {
         let sample_count = faces.iter().map(|face| face.2.len()).sum();
         let mut codepoints = Vec::with_capacity(sample_count);
         let mut glyph_ids = Vec::with_capacity(sample_count);
+        let mut outline_lengths = Vec::with_capacity(sample_count);
         offsets.push(0);
-        for (path, face_index, face_codepoints, face_glyph_ids) in faces {
+        for (path, face_index, face_codepoints, face_glyph_ids, face_outline_lengths) in faces {
             debug_assert!(face_codepoints.is_sorted());
             debug_assert_eq!(face_codepoints.len(), face_glyph_ids.len());
+            debug_assert_eq!(face_codepoints.len(), face_outline_lengths.len());
             fonts.push((path, face_index));
             codepoints.extend(face_codepoints);
             glyph_ids.extend(face_glyph_ids);
+            outline_lengths.extend(face_outline_lengths);
             offsets.push(i64::try_from(codepoints.len()).expect("Vec length fits in i64"));
         }
         // Rank every codepoint through a table indexed by the codepoint itself.
@@ -80,6 +85,7 @@ impl CodepointIndex {
             character_codepoints,
             character_index,
             glyph_ids,
+            outline_lengths,
         }
     }
 }
@@ -90,17 +96,21 @@ impl GlyphIndex {
         let mut fonts = Vec::with_capacity(faces.len());
         let mut offsets = Vec::with_capacity(faces.len() + 1);
         let mut glyph_ids = Vec::with_capacity(faces.iter().map(|face| face.2.len()).sum());
+        let mut outline_lengths = Vec::with_capacity(glyph_ids.capacity());
         offsets.push(0);
-        for (path, face_index, face_glyph_ids) in faces {
+        for (path, face_index, face_glyph_ids, face_outline_lengths) in faces {
             debug_assert!(face_glyph_ids.is_sorted());
+            debug_assert_eq!(face_glyph_ids.len(), face_outline_lengths.len());
             fonts.push((path, face_index));
             glyph_ids.extend(face_glyph_ids);
+            outline_lengths.extend(face_outline_lengths);
             offsets.push(i64::try_from(glyph_ids.len()).expect("Vec length fits in i64"));
         }
         Self {
             fonts,
             offsets,
             glyph_ids,
+            outline_lengths,
         }
     }
 }
@@ -114,8 +124,14 @@ mod tests {
     #[test]
     fn indexes_each_face_codepoint_once() {
         let index = CodepointIndex::build(vec![
-            (PathBuf::from("a.ttf"), 0, vec![65, 67], vec![36, 38]),
-            (PathBuf::from("b.ttf"), 1, vec![66], vec![5]),
+            (
+                PathBuf::from("a.ttf"),
+                0,
+                vec![65, 67],
+                vec![36, 38],
+                vec![9, 7],
+            ),
+            (PathBuf::from("b.ttf"), 1, vec![66], vec![5], vec![4]),
         ]);
         assert_eq!(
             index.fonts,
@@ -125,6 +141,7 @@ mod tests {
         assert_eq!(index.character_codepoints, vec![65, 66, 67]);
         assert_eq!(index.character_index, vec![0, 2, 1]);
         assert_eq!(index.glyph_ids, vec![36, 38, 5]);
+        assert_eq!(index.outline_lengths, vec![9, 7, 4]);
     }
 
     #[test]
@@ -135,13 +152,14 @@ mod tests {
         assert!(index.character_codepoints.is_empty());
         assert!(index.character_index.is_empty());
         assert!(index.glyph_ids.is_empty());
+        assert!(index.outline_lengths.is_empty());
     }
 
     #[test]
     fn indexes_each_face_glyph_once() {
         let index = GlyphIndex::build(vec![
-            (PathBuf::from("a.ttf"), 0, vec![0, 1, 2]),
-            (PathBuf::from("b.ttf"), 1, vec![0, 1]),
+            (PathBuf::from("a.ttf"), 0, vec![0, 1, 2], vec![2, 4, 6]),
+            (PathBuf::from("b.ttf"), 1, vec![0, 1], vec![3, 5]),
         ]);
         assert_eq!(
             index.fonts,
@@ -149,6 +167,7 @@ mod tests {
         );
         assert_eq!(index.offsets, vec![0, 3, 5]);
         assert_eq!(index.glyph_ids, vec![0, 1, 2, 0, 1]);
+        assert_eq!(index.outline_lengths, vec![2, 4, 6, 3, 5]);
     }
 
     #[test]
@@ -157,5 +176,6 @@ mod tests {
         assert!(index.fonts.is_empty());
         assert_eq!(index.offsets, vec![0]);
         assert!(index.glyph_ids.is_empty());
+        assert!(index.outline_lengths.is_empty());
     }
 }

--- a/src/py/dataset/index.rs
+++ b/src/py/dataset/index.rs
@@ -14,9 +14,15 @@ type CodepointIndexArrays = (
     Py<PyArray1<u32>>,
     Py<PyArray1<u32>>,
     Py<PyArray1<u32>>,
+    Py<PyArray1<u32>>,
 );
 
-type GlyphIndexArrays = (Vec<(PathBuf, u32)>, Vec<i64>, Py<PyArray1<u32>>);
+type GlyphIndexArrays = (
+    Vec<(PathBuf, u32)>,
+    Vec<i64>,
+    Py<PyArray1<u32>>,
+    Py<PyArray1<u32>>,
+);
 
 #[pyfunction]
 pub(super) fn index_codepoints(
@@ -45,6 +51,7 @@ pub(super) fn index_codepoints(
             .unbind(),
         index.character_index.into_pyarray(py).unbind(),
         index.glyph_ids.into_pyarray(py).unbind(),
+        index.outline_lengths.into_pyarray(py).unbind(),
     ))
 }
 
@@ -68,6 +75,7 @@ pub(super) fn index_glyphs(
         index.fonts,
         index.offsets,
         index.glyph_ids.into_pyarray(py).unbind(),
+        index.outline_lengths.into_pyarray(py).unbind(),
     ))
 }
 

--- a/tests/test_codepoint_dataset.py
+++ b/tests/test_codepoint_dataset.py
@@ -54,6 +54,11 @@ def test_dataset_indexes_each_face_codepoint_once() -> None:
     assert dataset.font_targets.tolist() == [0, 0]
     assert dataset.character_targets.tolist() == [0, 1]
     assert dataset.character_classes == ["A", "B"]
+    assert dataset.outline_lengths.dtype == torch.long
+    assert dataset.outline_lengths.shape == (len(dataset),)
+    assert dataset.outline_lengths.tolist() == [
+        len(LoadGlyph()(dataset[idx]).data) for idx in range(len(dataset))
+    ]
     sample = dataset[0]
     assert isinstance(sample, CodepointSample)
     assert isinstance(sample.ref, GlyphRef)
@@ -286,6 +291,7 @@ def test_dataset_is_pickleable() -> None:
     assert restored_sample.character_idx == sample.character_idx
     assert torch.equal(restored.font_targets, dataset.font_targets)
     assert torch.equal(restored.character_targets, dataset.character_targets)
+    assert torch.equal(restored.outline_lengths, dataset.outline_lengths)
 
 
 @pytest.mark.parametrize("index", [-2, 1])
@@ -334,6 +340,7 @@ def test_pattern_filter_and_outline_less_fonts_are_empty() -> None:
     assert len(missing) == 0
     assert missing.font_targets.shape == (0,)
     assert missing.character_targets.shape == (0,)
+    assert missing.outline_lengths.shape == (0,)
     assert len(no_outlines) == 0
 
 

--- a/tests/test_glyph_id_dataset.py
+++ b/tests/test_glyph_id_dataset.py
@@ -37,6 +37,11 @@ def test_dataset_indexes_every_outline_glyph_of_each_face() -> None:
 
     assert len(dataset) == font["maxp"].numGlyphs
     assert dataset.glyph_ids.tolist() == list(range(len(dataset)))
+    assert dataset.outline_lengths.dtype == torch.long
+    assert dataset.outline_lengths.shape == (len(dataset),)
+    assert dataset.outline_lengths.tolist() == [
+        len(LoadGlyph()(dataset[idx]).data) for idx in range(len(dataset))
+    ]
     sample = dataset[0]
     assert isinstance(sample, GlyphIdSample)
     assert isinstance(sample.ref, GlyphRef)
@@ -159,6 +164,7 @@ def test_dataset_is_pickleable() -> None:
     assert restored[36] == dataset[36]
     assert torch.equal(restored.font_targets, dataset.font_targets)
     assert torch.equal(restored.glyph_ids, dataset.glyph_ids)
+    assert torch.equal(restored.outline_lengths, dataset.outline_lengths)
 
 
 def test_dataset_accepts_negative_index() -> None:
@@ -184,6 +190,7 @@ def test_pattern_filter_and_outline_less_fonts_are_empty() -> None:
     assert len(missing) == 0
     assert missing.font_targets.shape == (0,)
     assert missing.glyph_ids.shape == (0,)
+    assert missing.outline_lengths.shape == (0,)
     assert len(no_outlines) == 0
     assert no_outlines.font_classes == []
 

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -89,6 +89,7 @@ def index_codepoints(
     npt.NDArray[np.uint32],
     npt.NDArray[np.uint32],
     npt.NDArray[np.uint32],
+    npt.NDArray[np.uint32],
 ]: ...
 def index_glyphs(
     root: str,
@@ -97,6 +98,7 @@ def index_glyphs(
 ) -> tuple[
     list[tuple[Path, int]],
     list[int],
+    npt.NDArray[np.uint32],
     npt.NDArray[np.uint32],
 ]: ...
 def load_glyph(

--- a/torchfont/datasets/_codepoint.py
+++ b/torchfont/datasets/_codepoint.py
@@ -53,6 +53,7 @@ class CodepointDataset(Dataset[T], Generic[T]):
     _character_codepoints: npt.NDArray[np.uint32]
     _character_index: npt.NDArray[np.uint32]
     _glyph_ids: npt.NDArray[np.uint32]
+    _outline_lengths: npt.NDArray[np.uint32]
 
     @overload
     def __init__(
@@ -96,12 +97,14 @@ class CodepointDataset(Dataset[T], Generic[T]):
             self._character_codepoints,
             self._character_index,
             self._glyph_ids,
+            self._outline_lengths,
         ) = _torchfont.index_codepoints(
             str(self.root), self.codepoints, self.max_length, self.patterns
         )
         self._character_codepoints.flags.writeable = False
         self._character_index.flags.writeable = False
         self._glyph_ids.flags.writeable = False
+        self._outline_lengths.flags.writeable = False
         self._font_refs = tuple(
             FontRef(path, face_index) for path, face_index in font_refs
         )
@@ -141,6 +144,11 @@ class CodepointDataset(Dataset[T], Generic[T]):
     def character_targets(self) -> Tensor:
         """LongTensor of character target indices for each sample."""
         return torch.from_numpy(self._character_index.astype(np.int64))
+
+    @property
+    def outline_lengths(self) -> Tensor:
+        """LongTensor of encoded outline lengths for each sample."""
+        return torch.from_numpy(self._outline_lengths.astype(np.int64))
 
     @overload
     def __getitem__(

--- a/torchfont/datasets/_glyph_id.py
+++ b/torchfont/datasets/_glyph_id.py
@@ -48,6 +48,7 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
     _font_refs: tuple[FontRef, ...]
     _offsets: tuple[int, ...]
     _glyph_ids: npt.NDArray[np.uint32]
+    _outline_lengths: npt.NDArray[np.uint32]
 
     @overload
     def __init__(
@@ -81,10 +82,11 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
         self.transform = transform
         self.patterns = normalize_patterns(patterns)
         self.max_length = normalize_max_length(max_length)
-        (font_refs, offsets, self._glyph_ids) = _torchfont.index_glyphs(
-            str(self.root), self.max_length, self.patterns
+        (font_refs, offsets, self._glyph_ids, self._outline_lengths) = (
+            _torchfont.index_glyphs(str(self.root), self.max_length, self.patterns)
         )
         self._glyph_ids.flags.writeable = False
+        self._outline_lengths.flags.writeable = False
         self._font_refs = tuple(
             FontRef(path, face_index) for path, face_index in font_refs
         )
@@ -113,6 +115,11 @@ class GlyphIdDataset(Dataset[T], Generic[T]):
     def glyph_ids(self) -> Tensor:
         """LongTensor of face-local glyph ids for each sample."""
         return torch.from_numpy(self._glyph_ids.astype(np.int64))
+
+    @property
+    def outline_lengths(self) -> Tensor:
+        """LongTensor of encoded outline lengths for each sample."""
+        return torch.from_numpy(self._outline_lengths.astype(np.int64))
 
     @overload
     def __getitem__(


### PR DESCRIPTION
## Summary

- compute and retain encoded outline lengths while indexing font faces
- expose `outline_lengths` as a per-sample `LongTensor` on both datasets
- document and test ordering, dtype, empty datasets, and pickle behavior

## Validation

- `mise run check`
- `mise run test` (495 passed, 15 skipped)
- `mise run docs-build`