### PR TITLE
Add reduction to OutlineLoss

### DIFF
--- a/docs/en/reference/nn.md
+++ b/docs/en/reference/nn.md
@@ -68,19 +68,25 @@ into one training objective:
 ```python
 from torchfont.nn import OutlineLoss
 
-criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
+criterion = OutlineLoss(
+    type_weight=1.0,
+    coordinate_weight=0.5,
+    reduction="mean",
+)
 loss = criterion(type_logits, predicted_coords, target_types, target_coords)
 ```
 
-`type_logits` has shape `(..., N, len(ElementType))`. Cross entropy is averaged over
-non-padding
-elements, while coordinate error is averaged independently over active
-coordinate scalars. The two means are then combined using `type_weight` and
-`coordinate_weight`. This keeps their relative weighting stable across outline
-lengths and padding amounts. An all-padding input produces a differentiable
-zero loss.
+`type_logits` has shape `(..., N, len(ElementType))`. Cross entropy and
+coordinate error are combined using `type_weight` and `coordinate_weight`.
+Padding elements and inactive coordinate slots do not contribute. An
+all-padding input produces a differentiable zero loss.
 
-The loss intentionally has no `reduction` argument. Use PyTorch cross entropy
-and `coordinate_mse_loss` separately when unreduced components or a different
-aggregation are required. The equivalent functional API is
-`torchfont.nn.functional.outline_loss`.
+`reduction` supports `"none"`, `"mean"`, and `"sum"`. With `"none"`, losses
+are summed within each outline and the output shape is `target_types.shape[:-1]`.
+With `"sum"`, these outline losses are summed. With `"mean"` (the default),
+cross entropy is averaged over all non-padding elements and coordinate error is
+averaged independently over all active coordinate scalars.
+
+Use PyTorch cross entropy and `coordinate_mse_loss` separately when unreduced
+components or different aggregation behavior is required. The equivalent
+functional API is `torchfont.nn.functional.outline_loss`.

--- a/docs/en/reference/nn.md
+++ b/docs/en/reference/nn.md
@@ -27,9 +27,8 @@ padding_mask = types == ElementType.PAD  # (1, 4)
 The module adds a learned element-type embedding to a bias-free linear
 projection of the six continuous coordinates. Coordinate components inactive
 for an element type are masked before projection. `ElementType.PAD` is the
-`padding_idx`, and complete padding tokens produce zero vectors. Positional
-information is intentionally separate: use the positional encoding appropriate
-for the downstream sequence architecture.
+`padding_idx`, and complete padding tokens produce zero vectors. Add positional
+encoding appropriate for the downstream sequence architecture separately.
 
 The constructor accepts PyTorch-style `device` and `dtype` keyword arguments:
 
@@ -87,6 +86,6 @@ With `"sum"`, these outline losses are summed. With `"mean"` (the default),
 cross entropy is averaged over all non-padding elements and coordinate error is
 averaged independently over all active coordinate scalars.
 
-Use PyTorch cross entropy and `coordinate_mse_loss` separately when unreduced
-components or different aggregation behavior is required. The equivalent
-functional API is `torchfont.nn.functional.outline_loss`.
+PyTorch cross entropy and `coordinate_mse_loss` provide the individual
+classification and coordinate components. The equivalent functional API for
+the combined loss is `torchfont.nn.functional.outline_loss`.

--- a/docs/ja/reference/nn.md
+++ b/docs/ja/reference/nn.md
@@ -60,15 +60,23 @@ Prediction と Target 座標の Shape は `(..., N, 6)`、Target 型は `(..., N
 ```python
 from torchfont.nn import OutlineLoss
 
-criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
+criterion = OutlineLoss(
+    type_weight=1.0,
+    coordinate_weight=0.5,
+    reduction="mean",
+)
 loss = criterion(type_logits, predicted_coords, target_types, target_coords)
 ```
 
-`type_logits` の Shape は `(..., N, len(ElementType))` です。Cross Entropy は Padding 以外の要素で平均し、
-座標誤差は有効な座標 Scalar で独立に平均します。その後、二つの Mean を `type_weight` と
-`coordinate_weight` で重み付けします。このため、Outline の長さや Padding 量が変化しても、
-相対的な重みが安定します。すべてが Padding の Input に対しては、微分可能なゼロ Loss を返します。
+`type_logits` の Shape は `(..., N, len(ElementType))` です。Cross Entropy と座標誤差を
+`type_weight` と `coordinate_weight` で重み付けします。Padding 要素と無効な座標 Slot は
+Loss に寄与しません。すべてが Padding の Input に対しては、微分可能なゼロ Loss を返します。
 
-この Loss は意図的に `reduction` Argument を持ちません。集約前の成分や異なる集約方法が
-必要な場合は、PyTorch の Cross Entropy と `coordinate_mse_loss` を個別に使ってください。
+`reduction` は `"none"`、`"mean"`、`"sum"` に対応します。`"none"` では Outline ごとに
+Loss を合計し、`target_types.shape[:-1]` Shape の Tensor を返します。`"sum"` ではそれらを
+さらに合計します。既定の `"mean"` では、Cross Entropy をすべての Padding 以外の要素で、
+座標誤差をすべての有効な座標 Scalar で独立に平均します。
+
+集約前の各成分や異なる集約方法が必要な場合は、PyTorch の Cross Entropy と
+`coordinate_mse_loss` を個別に使ってください。
 同等の関数 API は `torchfont.nn.functional.outline_loss` です。

--- a/docs/ja/reference/nn.md
+++ b/docs/ja/reference/nn.md
@@ -26,7 +26,7 @@ padding_mask = types == ElementType.PAD  # (1, 4)
 学習可能な要素型 Embedding と、Bias なしの線形層による6次元連続座標の射影を加算します。
 要素型に対して無効な座標成分は、射影前に Mask されます。
 `ElementType.PAD` を `padding_idx` とし、Padding Token 全体の出力はゼロになります。
-位置情報は意図的に分離しています。下流の系列アーキテクチャに適した位置 Encoding を使ってください。
+下流の系列アーキテクチャに適した位置 Encoding は別途追加します。
 
 Constructor は PyTorch と同様に `device` と `dtype` Keyword Argument を受け取ります。
 
@@ -77,6 +77,5 @@ Loss を合計し、`target_types.shape[:-1]` Shape の Tensor を返します�
 さらに合計します。既定の `"mean"` では、Cross Entropy をすべての Padding 以外の要素で、
 座標誤差をすべての有効な座標 Scalar で独立に平均します。
 
-集約前の各成分や異なる集約方法が必要な場合は、PyTorch の Cross Entropy と
-`coordinate_mse_loss` を個別に使ってください。
-同等の関数 API は `torchfont.nn.functional.outline_loss` です。
+PyTorch の Cross Entropy と `coordinate_mse_loss` は、分類と座標の各成分を個別に提供します。
+組み合わせた Loss の同等の関数 API は `torchfont.nn.functional.outline_loss` です。

--- a/tests/nn/test_loss.py
+++ b/tests/nn/test_loss.py
@@ -42,17 +42,67 @@ def test_outline_loss_combines_independently_averaged_losses() -> None:
 
 def test_outline_loss_module_delegates_to_functional_loss() -> None:
     inputs = _inputs()
-    criterion = OutlineLoss(type_weight=0.25, coordinate_weight=2.0)
+    criterion = OutlineLoss(type_weight=0.25, coordinate_weight=2.0, reduction="sum")
 
     actual = criterion(*inputs)
     expected = font_functional.outline_loss(
         *inputs,
         type_weight=0.25,
         coordinate_weight=2.0,
+        reduction="sum",
     )
 
     assert torch.equal(actual, expected)
-    assert repr(criterion) == "OutlineLoss(type_weight=0.25, coordinate_weight=2.0)"
+    assert repr(criterion) == (
+        "OutlineLoss(type_weight=0.25, coordinate_weight=2.0, reduction='sum')"
+    )
+
+
+def test_outline_loss_none_returns_loss_per_outline() -> None:
+    type_logits, prediction, target_types, target_coords = _inputs()
+    type_logits = type_logits.unsqueeze(0).expand(2, -1, -1)
+    prediction = prediction.detach().unsqueeze(0).expand(2, -1, -1)
+    target_types = target_types.unsqueeze(0).expand(2, -1)
+    target_coords = target_coords.unsqueeze(0).expand(2, -1, -1)
+
+    loss = font_functional.outline_loss(
+        type_logits,
+        prediction,
+        target_types,
+        target_coords,
+        type_weight=2.0,
+        coordinate_weight=3.0,
+        reduction="none",
+    )
+    expected_type_loss = torch_functional.cross_entropy(
+        type_logits.transpose(1, 2),
+        target_types,
+        ignore_index=ElementType.PAD,
+        reduction="none",
+    ).sum(dim=-1)
+    expected_coord_loss = font_functional.coordinate_mse_loss(
+        prediction, target_types, target_coords, reduction="none"
+    ).sum(dim=(-2, -1))
+
+    assert loss.shape == (2,)
+    assert torch.allclose(loss, 2 * expected_type_loss + 3 * expected_coord_loss)
+
+
+def test_outline_loss_sum_sums_unreduced_outline_losses() -> None:
+    type_logits, prediction, target_types, target_coords = _inputs()
+    type_logits = type_logits.unsqueeze(0).expand(2, -1, -1)
+    prediction = prediction.detach().unsqueeze(0).expand(2, -1, -1)
+    target_types = target_types.unsqueeze(0).expand(2, -1)
+    target_coords = target_coords.unsqueeze(0).expand(2, -1, -1)
+
+    unreduced = font_functional.outline_loss(
+        type_logits, prediction, target_types, target_coords, reduction="none"
+    )
+    reduced = font_functional.outline_loss(
+        type_logits, prediction, target_types, target_coords, reduction="sum"
+    )
+
+    assert torch.equal(reduced, unreduced.sum())
 
 
 def test_outline_loss_backpropagates_through_both_predictions() -> None:
@@ -98,4 +148,12 @@ def test_outline_loss_rejects_misaligned_type_logits(
     with pytest.raises(ValueError, match=match):
         font_functional.outline_loss(
             torch.zeros(logits_shape), prediction, target_types, target_coords
+        )
+
+
+def test_outline_loss_rejects_invalid_reduction() -> None:
+    with pytest.raises(ValueError, match="not a valid value"):
+        font_functional.outline_loss(
+            *_inputs(),
+            reduction="invalid",  # ty: ignore[invalid-argument-type]
         )

--- a/torchfont/nn/functional.py
+++ b/torchfont/nn/functional.py
@@ -58,12 +58,15 @@ def outline_loss(
     *,
     type_weight: float = 1.0,
     coordinate_weight: float = 100.0,
+    reduction: _Reduction = "mean",
 ) -> Tensor:
     """Combine element-type classification and active-coordinate regression.
 
-    Type loss is averaged over non-padding elements. Coordinate loss is
-    averaged independently over coordinate scalars active for the target
-    element types, then the two means are combined using the given weights.
+    With ``reduction="none"``, losses are summed within each outline and the
+    result has shape ``target_types.shape[:-1]``. ``"sum"`` sums those outline
+    losses. ``"mean"`` averages type loss over all non-padding elements and
+    coordinate loss independently over all active coordinate scalars before
+    combining them using the given weights.
     """
     if type_logits.shape[:-1] != target_types.shape:
         msg = (
@@ -80,14 +83,26 @@ def outline_loss(
         type_logits.reshape(-1, _NUM_ELEMENT_TYPES),
         target_types.reshape(-1),
         ignore_index=ElementType.PAD.value,
-        reduction="sum",
-    )
-    type_count = (target_types != ElementType.PAD.value).sum().clamp_min(1)
-    type_loss = type_loss / type_count
+        reduction="none",
+    ).reshape(target_types.shape)
     coords_loss = coordinate_mse_loss(
-        coordinate_prediction, target_types, target_coords
+        coordinate_prediction, target_types, target_coords, reduction="none"
     )
-    return type_weight * type_loss + coordinate_weight * coords_loss
+    if reduction == "none":
+        return type_weight * type_loss.sum(
+            dim=-1
+        ) + coordinate_weight * coords_loss.sum(dim=(-2, -1))
+    if reduction == "sum":
+        return type_weight * type_loss.sum() + coordinate_weight * coords_loss.sum()
+    if reduction == "mean":
+        type_count = (target_types != ElementType.PAD.value).sum().clamp_min(1)
+        coordinate_count = _active_coordinate_mask(target_types).sum().clamp_min(1)
+        return (
+            type_weight * type_loss.sum() / type_count
+            + coordinate_weight * coords_loss.sum() / coordinate_count
+        )
+    msg = f"{reduction!r} is not a valid value for reduction"
+    raise ValueError(msg)
 
 
 __all__ = ["coordinate_mse_loss", "outline_loss"]

--- a/torchfont/nn/modules/loss.py
+++ b/torchfont/nn/modules/loss.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from torch import nn
 
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 class OutlineLoss(nn.Module):
     """Combine element-type and active-coordinate losses.
 
-    The two losses are averaged independently before ``type_weight`` and
-    ``coordinate_weight`` are applied. Padding elements do not contribute.
+    ``reduction`` controls aggregation across outlines. Padding elements do not
+    contribute.
     """
 
     def __init__(
@@ -24,11 +24,13 @@ class OutlineLoss(nn.Module):
         *,
         type_weight: float = 1.0,
         coordinate_weight: float = 100.0,
+        reduction: Literal["none", "mean", "sum"] = "mean",
     ) -> None:
-        """Initialize the weights applied to both loss components."""
+        """Initialize the weights and reduction applied to the loss."""
         super().__init__()
         self.type_weight = type_weight
         self.coordinate_weight = coordinate_weight
+        self.reduction = reduction
 
     def forward(
         self,
@@ -45,13 +47,15 @@ class OutlineLoss(nn.Module):
             target_coords,
             type_weight=self.type_weight,
             coordinate_weight=self.coordinate_weight,
+            reduction=self.reduction,
         )
 
     def extra_repr(self) -> str:
         """Return the module configuration for :func:`repr`."""
         return (
             f"type_weight={self.type_weight}, "
-            f"coordinate_weight={self.coordinate_weight}"
+            f"coordinate_weight={self.coordinate_weight}, "
+            f"reduction={self.reduction!r}"
         )
 
 


### PR DESCRIPTION
## Summary

- add PyTorch-style `none`, `mean`, and `sum` reductions to `OutlineLoss` and `outline_loss`
- preserve the existing independently normalized behavior as the default `mean` reduction
- return one summed loss per outline for `none`, with `sum` equal to the sum of those losses
- document the behavior in English and Japanese

## Validation

- `mise run python-format`
- `uv run --locked --no-sync pytest tests` (498 passed, 15 skipped)
- `mise run python-check`
- `mise run docs-build`
- `git diff --check`